### PR TITLE
Expose appointment slots via REST and update frontend to consume them with empty-state handling

### DIFF
--- a/assets-src/js/booking.js
+++ b/assets-src/js/booking.js
@@ -262,8 +262,13 @@ appointment.addEventListener("change", () => {
   answers.appointment = null;
   checkMandatoryFields();
 
-  // modificare l'url se si vuole integrare con un servizio esterno
-  fetch(url + `?month=${appointment?.value}&office=${answers?.place?.id}`)
+  const urlParam = new URLSearchParams({
+    id: answers?.office?.id,
+    month: appointment?.value,
+    year: new Date().getFullYear(),
+  });
+
+  fetch(`${window.wpRestApi}wp/v2/appuntamenti/ufficio/?${urlParam}`)
     .then((response) => {
       if (!response.ok) {
         throw new Error("HTTP error " + response.status);
@@ -271,9 +276,17 @@ appointment.addEventListener("change", () => {
       return response.json();
     })
     .then((data) => {
-      data = data[appointment?.value]
+      data = Array.isArray(data) ? data : data?.[appointment?.value] || [];
       document.querySelector("#radio-appointment").innerHTML =
         '<legend class="visually-hidden">Seleziona un giorno e orario</legend>';
+
+      if (!data.length) {
+        document.querySelector("#radio-appointment").innerHTML += `
+        <p class="mt-2 mb-0">Nessun appuntamento disponibile per il mese selezionato.</p>
+        `;
+        return;
+      }
+
       for (const dates of data) {
         const { startDate, endDate } = dates;
         const startDay = startDate.split("T")[0];

--- a/assets/js/booking.js
+++ b/assets/js/booking.js
@@ -36,14 +36,16 @@ function borderCardRadio(){var t=document.querySelectorAll(".radio-card");docume
           </div>
           `}borderCardRadio()}).catch(e=>{console.log("err",e)}),fetch(window.wpRestApi+"wp/v2/servizi/ufficio?"+e).then(e=>e.json()).then(e=>{document.querySelector("#motivo-appuntamento").innerHTML='<option selected="selected" value="">Seleziona opzione</option>';for(const t of e)document.querySelector("#motivo-appuntamento").innerHTML+=`
           <option value="${t?.ID}">${t?.post_title}</option>
-          `}).catch(e=>{console.log("err",e)})):document.querySelector("#place-cards-wrapper").innerHTML=""}),document.getElementById("appointment")),setSelectedPlace=(appointment.addEventListener("change",()=>{answers.appointment=null,checkMandatoryFields(),fetch(url+(`?month=${appointment?.value}&office=`+answers?.place?.id)).then(e=>{if(e.ok)return e.json();throw new Error("HTTP error "+e.status)}).then(e=>{e=e[appointment?.value],document.querySelector("#radio-appointment").innerHTML='<legend class="visually-hidden">Seleziona un giorno e orario</legend>';for(const s of e){var{startDate:t,endDate:n}=s,r=t.split("T")[0],r=new Date(r).toLocaleString([],{weekday:"long",day:"2-digit",month:"long",year:"numeric"}),a=t+"/"+n,n=encodeObject({startDate:t,endDate:n});document.querySelector("#radio-appointment").innerHTML+=`
+          `}).catch(e=>{console.log("err",e)})):document.querySelector("#place-cards-wrapper").innerHTML=""}),document.getElementById("appointment")),setSelectedPlace=(appointment.addEventListener("change",()=>{answers.appointment=null,checkMandatoryFields();var e=new URLSearchParams({id:answers?.office?.id,month:appointment?.value,year:(new Date).getFullYear()});fetch(window.wpRestApi+"wp/v2/appuntamenti/ufficio/?"+e).then(e=>{if(e.ok)return e.json();throw new Error("HTTP error "+e.status)}).then(e=>{if(e=Array.isArray(e)?e:e?.[appointment?.value]||[],document.querySelector("#radio-appointment").innerHTML='<legend class="visually-hidden">Seleziona un giorno e orario</legend>',e.length)for(const s of e){var{startDate:t,endDate:n}=s,r=t.split("T")[0],r=new Date(r).toLocaleString([],{weekday:"long",day:"2-digit",month:"long",year:"numeric"}),a=t+"/"+n,n=encodeObject({startDate:t,endDate:n});document.querySelector("#radio-appointment").innerHTML+=`
         <div
         class="radio-body border-bottom border-light"
         >
         <input name="radio" type="radio" id="${a}" onclick="saveAnswerByValue('appointment', '${n}', true)"/>
         <label for="${a}" class="text-capitalize">${r} ore ${t.split("T")[1]}</label>
         </div>
-        `}}).catch(e=>{console.log("err",e)})}),()=>{var e=answers?.place;document.querySelector("#selected-place-card").innerHTML=`  
+        `}else document.querySelector("#radio-appointment").innerHTML+=`
+        <p class="mt-2 mb-0">Nessun appuntamento disponibile per il mese selezionato.</p>
+        `}).catch(e=>{console.log("err",e)})}),()=>{var e=answers?.place;document.querySelector("#selected-place-card").innerHTML=`  
   <div class="cmp-info-summary bg-white mb-4 mb-lg-30 p-4">
   <div class="card">
       <div

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -84,6 +84,192 @@ function dci_register_servizi_ufficio_route() {
 add_action('rest_api_init', 'dci_register_servizi_ufficio_route');
 
 /**
+ * Espone gli slot prenotabili costruiti dall'orario associato all'Unità organizzativa.
+ */
+function dci_register_appuntamenti_ufficio_route() {
+    register_rest_route('wp/v2', '/appuntamenti/ufficio/', array(
+        'methods' => 'GET',
+        'callback' => 'dci_get_appuntamenti_ufficio'
+    ));
+}
+add_action('rest_api_init', 'dci_register_appuntamenti_ufficio_route');
+
+/**
+ * Genera gli slot appuntamento del mese richiesto a partire dall'orario UO.
+ *
+ * @param WP_REST_Request $request
+ * @return array
+ */
+function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
+    $office_id = absint($request->get_param('id'));
+    $month = absint($request->get_param('month'));
+    $year = absint($request->get_param('year'));
+
+    if ($office_id <= 0) {
+        return array(
+            "error" => array(
+                "code" => 400,
+                "message" => "Parametro id mancante o non valido."
+            )
+        );
+    }
+
+    if ($month < 1 || $month > 12) {
+        $month = (int) wp_date('n');
+    }
+    if ($year < 1) {
+        $year = (int) wp_date('Y');
+    }
+
+    $orario_id = absint(dci_get_meta('orario_uo', '_dci_unita_organizzativa_', $office_id));
+    if ($orario_id <= 0) {
+        return array();
+    }
+
+    $prefix = '_dci_orario_';
+    $data_inizio_raw = get_post_meta($orario_id, $prefix . 'data_inizio', true);
+    $data_fine_raw = get_post_meta($orario_id, $prefix . 'data_fine', true);
+
+    $data_inizio = DateTime::createFromFormat('d-m-Y', $data_inizio_raw) ?: null;
+    $data_fine = DateTime::createFromFormat('d-m-Y', $data_fine_raw) ?: null;
+    if (!$data_inizio || !$data_fine) {
+        return array();
+    }
+
+    $first_day = DateTime::createFromFormat('Y-n-j H:i:s', $year . '-' . $month . '-1 00:00:00');
+    $last_day = clone $first_day;
+    $last_day->modify('last day of this month')->setTime(23, 59, 59);
+
+    $slot_duration = 45; // minuti
+    $giorni_map = array(
+        1 => 'lun',
+        2 => 'mar',
+        3 => 'mer',
+        4 => 'gio',
+        5 => 'ven',
+        6 => 'sab',
+        7 => 'dom',
+    );
+
+    $slots = array();
+    $cursor = clone $first_day;
+    $now = new DateTime('now', wp_timezone());
+
+    while ($cursor <= $last_day) {
+        if ($cursor >= $data_inizio && $cursor <= $data_fine && !dci_is_festivo_nazionale($cursor)) {
+            $weekday = (int) $cursor->format('N');
+            $day_prefix = $giorni_map[$weekday];
+
+            $mattina = get_post_meta($orario_id, $prefix . $day_prefix . '_mattina', true);
+            $pomeriggio = get_post_meta($orario_id, $prefix . $day_prefix . '_pomeriggio', true);
+
+            $fasce = array_filter(array($mattina, $pomeriggio));
+            foreach ($fasce as $fascia) {
+                $parsed = dci_parse_orario_range($fascia);
+                if (!$parsed) {
+                    continue;
+                }
+
+                list($start_h, $start_m, $end_h, $end_m) = $parsed;
+                $slot_start = (clone $cursor)->setTime($start_h, $start_m, 0);
+                $slot_end_limit = (clone $cursor)->setTime($end_h, $end_m, 0);
+
+                while ((clone $slot_start)->modify('+' . $slot_duration . ' minutes') <= $slot_end_limit) {
+                    $slot_end = (clone $slot_start)->modify('+' . $slot_duration . ' minutes');
+                    if ($slot_start <= $now) {
+                        $slot_start = $slot_end;
+                        continue;
+                    }
+
+                    $slots[] = array(
+                        'startDate' => $slot_start->format('Y-m-d\TH:i'),
+                        'endDate' => $slot_end->format('Y-m-d\TH:i'),
+                    );
+                    $slot_start = $slot_end;
+                }
+            }
+        }
+
+        $cursor->modify('+1 day')->setTime(0, 0, 0);
+    }
+
+    return $slots;
+}
+
+/**
+ * Verifica se una data ricade in un giorno festivo nazionale.
+ *
+ * @param DateTime $date
+ * @return bool
+ */
+function dci_is_festivo_nazionale(DateTime $date) {
+    // Tutte le domeniche sono giorni festivi a livello nazionale.
+    if ((int) $date->format('N') === 7) {
+        return true;
+    }
+
+    $fixed_holidays = array(
+        '01-01', // Capodanno
+        '01-06', // Epifania
+        '04-25', // Liberazione
+        '05-01', // Festa del Lavoro
+        '06-02', // Festa della Repubblica
+        '08-15', // Ferragosto
+        '11-01', // Ognissanti
+        '12-08', // Immacolata
+        '12-25', // Natale
+        '12-26', // Santo Stefano
+    );
+    $sicilia_holidays = array(
+        '05-15', // Festa dell'Autonomia Siciliana
+    );
+
+    $day_month = $date->format('m-d');
+    if (in_array($day_month, $fixed_holidays, true) || in_array($day_month, $sicilia_holidays, true)) {
+        return true;
+    }
+
+    $year = (int) $date->format('Y');
+    $easter_timestamp = easter_date($year);
+    $easter = (new DateTime('@' . $easter_timestamp))->setTimezone(wp_timezone());
+    $easter_monday = (clone $easter)->modify('+1 day');
+
+    return $date->format('Y-m-d') === $easter->format('Y-m-d') ||
+        $date->format('Y-m-d') === $easter_monday->format('Y-m-d');
+}
+
+/**
+ * Parsing range orario "08:30 - 12:30".
+ *
+ * @param string $range
+ * @return array|null
+ */
+function dci_parse_orario_range($range) {
+    if (!is_string($range) || trim($range) === '') {
+        return null;
+    }
+
+    if (!preg_match('/^\s*(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})\s*$/', $range, $matches)) {
+        return null;
+    }
+
+    $start_h = (int) $matches[1];
+    $start_m = (int) $matches[2];
+    $end_h = (int) $matches[3];
+    $end_m = (int) $matches[4];
+
+    if ($start_h > 23 || $end_h > 23 || $start_m > 59 || $end_m > 59) {
+        return null;
+    }
+
+    if ($end_h < $start_h || ($end_h === $start_h && $end_m <= $start_m)) {
+        return null;
+    }
+
+    return array($start_h, $start_m, $end_h, $end_m);
+}
+
+/**
  * restituisce i servizi che sono disponibili presso l'Unità Organizzativa passata come parametro (id o title)
  * @param WP_REST_Request $request
  * @return array[]

--- a/template-parts/prenotazione/content.php
+++ b/template-parts/prenotazione/content.php
@@ -1,7 +1,19 @@
 <?php
     $uffici = get_posts(array(
         'posts_per_page' => -1,
-        'post_type' => 'unita_organizzativa'
+        'post_type' => 'unita_organizzativa',
+        'meta_query' => array(
+            'relation' => 'AND',
+            array(
+                'key' => '_dci_unita_organizzativa_orario_uo',
+                'compare' => 'EXISTS',
+            ),
+            array(
+                'key' => '_dci_unita_organizzativa_orario_uo',
+                'value' => '',
+                'compare' => '!=',
+            ),
+        ),
     ));
 
     $months = array();
@@ -13,6 +25,18 @@
         $currentMonth++;
     }
 ?>
+
+<style>
+    #radio-appointment {
+        max-height: 420px;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #radio-appointment .radio-body label {
+        overflow-wrap: anywhere;
+    }
+</style>
 
 <div class="it-page-sections-container">
 


### PR DESCRIPTION
### Motivation
- Provide a server-side source of truth for available appointment slots built from each unit's schedule and expose it through the REST API.
- Ensure the frontend requests appointment slots from the new endpoint and gracefully handles empty months or absent data.
- Limit selectable offices to those that actually have an associated schedule to avoid requesting slots for units without working hours.

### Description
- Added a new REST route `wp/v2/appuntamenti/ufficio/` and implemented `dci_get_appuntamenti_ufficio` to generate per-month appointment slots from the unit schedule meta (`orario_uo`), using a 45-minute slot length and skipping Sundays and national/specific fixed holidays. 
- Introduced helper functions `dci_is_festivo_nazionale` to detect national holidays and `dci_parse_orario_range` to parse range strings like `08:30 - 12:30`. 
- Updated frontend in `assets-src/js/booking.js` (and the built `assets/js/booking.js`) to construct query params with `URLSearchParams`, fetch slots from `${window.wpRestApi}wp/v2/appuntamenti/ufficio/`, normalize the returned payload (`Array.isArray` check) and render a user-friendly message when no appointments are available. 
- Restricted `get_posts` in `template-parts/prenotazione/content.php` to only return `unita_organizzativa` posts that have the `_dci_unita_organizzativa_orario_uo` meta set, and added styling for `#radio-appointment` to limit height and improve label wrapping. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c253f15ac483329179896ef4f37fd3)