### PR TITLE
Expose appointment slots API; refactor booking/segnalazione JS; admin/email and CPT adjustments

### DIFF
--- a/assets-src/js/booking.js
+++ b/assets-src/js/booking.js
@@ -262,8 +262,13 @@ appointment.addEventListener("change", () => {
   answers.appointment = null;
   checkMandatoryFields();
 
-  // modificare l'url se si vuole integrare con un servizio esterno
-  fetch(url + `?month=${appointment?.value}&office=${answers?.place?.id}`)
+  const urlParam = new URLSearchParams({
+    id: answers?.office?.id,
+    month: appointment?.value,
+    year: new Date().getFullYear(),
+  });
+
+  fetch(`${window.wpRestApi}wp/v2/appuntamenti/ufficio/?${urlParam}`)
     .then((response) => {
       if (!response.ok) {
         throw new Error("HTTP error " + response.status);
@@ -271,9 +276,17 @@ appointment.addEventListener("change", () => {
       return response.json();
     })
     .then((data) => {
-      data = data[appointment?.value]
+      data = Array.isArray(data) ? data : data?.[appointment?.value] || [];
       document.querySelector("#radio-appointment").innerHTML =
         '<legend class="visually-hidden">Seleziona un giorno e orario</legend>';
+
+      if (!data.length) {
+        document.querySelector("#radio-appointment").innerHTML += `
+        <p class="mt-2 mb-0">Nessun appuntamento disponibile per il mese selezionato.</p>
+        `;
+        return;
+      }
+
       for (const dates of data) {
         const { startDate, endDate } = dates;
         const startDay = startDate.split("T")[0];

--- a/assets/js/booking.js
+++ b/assets/js/booking.js
@@ -36,14 +36,16 @@ function borderCardRadio(){var t=document.querySelectorAll(".radio-card");docume
           </div>
           `}borderCardRadio()}).catch(e=>{console.log("err",e)}),fetch(window.wpRestApi+"wp/v2/servizi/ufficio?"+e).then(e=>e.json()).then(e=>{document.querySelector("#motivo-appuntamento").innerHTML='<option selected="selected" value="">Seleziona opzione</option>';for(const t of e)document.querySelector("#motivo-appuntamento").innerHTML+=`
           <option value="${t?.ID}">${t?.post_title}</option>
-          `}).catch(e=>{console.log("err",e)})):document.querySelector("#place-cards-wrapper").innerHTML=""}),document.getElementById("appointment")),setSelectedPlace=(appointment.addEventListener("change",()=>{answers.appointment=null,checkMandatoryFields(),fetch(url+(`?month=${appointment?.value}&office=`+answers?.place?.id)).then(e=>{if(e.ok)return e.json();throw new Error("HTTP error "+e.status)}).then(e=>{e=e[appointment?.value],document.querySelector("#radio-appointment").innerHTML='<legend class="visually-hidden">Seleziona un giorno e orario</legend>';for(const s of e){var{startDate:t,endDate:n}=s,r=t.split("T")[0],r=new Date(r).toLocaleString([],{weekday:"long",day:"2-digit",month:"long",year:"numeric"}),a=t+"/"+n,n=encodeObject({startDate:t,endDate:n});document.querySelector("#radio-appointment").innerHTML+=`
+          `}).catch(e=>{console.log("err",e)})):document.querySelector("#place-cards-wrapper").innerHTML=""}),document.getElementById("appointment")),setSelectedPlace=(appointment.addEventListener("change",()=>{answers.appointment=null,checkMandatoryFields();var e=new URLSearchParams({id:answers?.office?.id,month:appointment?.value,year:(new Date).getFullYear()});fetch(window.wpRestApi+"wp/v2/appuntamenti/ufficio/?"+e).then(e=>{if(e.ok)return e.json();throw new Error("HTTP error "+e.status)}).then(e=>{if(e=Array.isArray(e)?e:e?.[appointment?.value]||[],document.querySelector("#radio-appointment").innerHTML='<legend class="visually-hidden">Seleziona un giorno e orario</legend>',e.length)for(const s of e){var{startDate:t,endDate:n}=s,r=t.split("T")[0],r=new Date(r).toLocaleString([],{weekday:"long",day:"2-digit",month:"long",year:"numeric"}),a=t+"/"+n,n=encodeObject({startDate:t,endDate:n});document.querySelector("#radio-appointment").innerHTML+=`
         <div
         class="radio-body border-bottom border-light"
         >
         <input name="radio" type="radio" id="${a}" onclick="saveAnswerByValue('appointment', '${n}', true)"/>
         <label for="${a}" class="text-capitalize">${r} ore ${t.split("T")[1]}</label>
         </div>
-        `}}).catch(e=>{console.log("err",e)})}),()=>{var e=answers?.place;document.querySelector("#selected-place-card").innerHTML=`  
+        `}else document.querySelector("#radio-appointment").innerHTML+=`
+        <p class="mt-2 mb-0">Nessun appuntamento disponibile per il mese selezionato.</p>
+        `}).catch(e=>{console.log("err",e)})}),()=>{var e=answers?.place;document.querySelector("#selected-place-card").innerHTML=`  
   <div class="cmp-info-summary bg-white mb-4 mb-lg-30 p-4">
   <div class="card">
       <div

--- a/assets/js/segnalazione.js
+++ b/assets/js/segnalazione.js
@@ -1,305 +1,214 @@
-function borderCardRadio() {
-    var t = document.querySelectorAll(".radio-card");
-    document.querySelectorAll(".radio-input").forEach(function(e, n) {
-        e.addEventListener("change", function() {
-            t.forEach(function(e, t) {
-                n == t ? e.classList.add("has-border-green") : e.classList.remove("has-border-green")
-            })
-        })
-    })
-}
-var content = document.querySelector(".section-wrapper"),
-    currentStep = 1,
-    navscroll = document.querySelector('[data-index="'.concat(currentStep, '"]')),
-    progressBar = document.querySelector('[data-progress="'.concat(currentStep, '"]')),
-    btnNext = content.querySelector(".btn-next-step"),
-    btnBack = content.querySelector(".btn-back-step");
+(function () {
+  var content = document.querySelector('.section-wrapper');
+  if (!content) return;
 
-function pageSteps() {
-    var e;
-    content && (e = content.querySelectorAll(".saveBtn"), navscroll.classList.add("d-lg-block"), progressBar.classList.remove("d-none"), e.forEach(function(e) {
-        e.classList.add("invisible")
-    }), btnNext && btnNext.addEventListener("click", function() {
-        openNext()
-    }), btnBack) && btnBack.addEventListener("click", function() {
-        backPrevious()
-    })
-}
+  var steps = Array.prototype.slice.call(content.querySelectorAll('[data-steps]'));
+  var btnNext = content.querySelector('.btn-next-step');
+  var btnBack = content.querySelector('.btn-back-step');
+  var alertMessage = document.getElementById('alert-message');
+  var currentStep = 1;
 
-function openNext() {
-    btnBack.disabled = !1;
-    var e = content.querySelectorAll(".saveBtn"),
-        t = content.querySelectorAll("[data-steps]"),
-        n = content.querySelector('[data-steps="'.concat(currentStep + 1, '"]')),
-        r = content.querySelector("[data-steps].active");
-    navscroll.classList.remove("d-lg-block"), progressBar.classList.remove("d-block"), progressBar.classList.add("d-none"), currentStep == t.length ? confirmAppointment() : (r.classList.add("d-none"), r.classList.remove("active"), n.classList.add("active"), n.classList.remove("d-none"), currentStep += 1, checkMandatoryFields(), (progressBar = document.querySelector('[data-progress="'.concat(currentStep, '"]'))).classList.add("d-block"), progressBar.classList.remove("d-none"), currentStep < t.length && (navscroll = document.querySelector('[data-index="'.concat(currentStep, '"]'))).classList.add("d-lg-block"), currentStep == t.length && content.classList.remove("offset-lg-1"), currentStep == t.length && (btnNext.disabled = !1, content.querySelector(".steppers-btn-confirm span").innerHTML = "Invia", e.forEach(function(e) {
-        e.classList.remove("invisible"), e.classList.add("visible"), setReviews()
-    })))
-}
+  function getEl(id) {
+    return document.getElementById(id);
+  }
 
-function backPrevious() {
-    btnNext.disabled = !1;
-    var e = content.querySelectorAll(".saveBtn"),
-        t = content.querySelectorAll("[data-steps]"),
-        n = content.querySelector("[data-steps].active"),
-        r = content.querySelector('[data-steps="'.concat(currentStep - 1, '"]'));
-    1 != currentStep && (r.classList.remove("d-none"), r.classList.add("active"), n.classList.add("d-none"), n.classList.remove("active"), navscroll.classList.remove("d-lg-block"), progressBar.classList.add("d-none"), currentStep -= 1, (progressBar = document.querySelector('[data-progress="'.concat(currentStep, '"]'))).classList.toggle("d-none"), content.querySelector(".steppers-btn-confirm span").innerHTML = "Avanti", currentStep < t.length && ((navscroll = document.querySelector('[data-index="'.concat(currentStep, '"]'))).classList.add("d-lg-block"), content.classList.add("offset-lg-1")), currentStep < t.length && e.forEach(function(e) {
-        e.classList.remove("visible"), e.classList.add("invisible")
-    }), 1 == currentStep) && (btnBack.disabled = !0)
-}
-pageSteps();
-const answers = {},
-    encodeObject = e => encodeURIComponent(JSON.stringify(e)),
-    decodeObj = e => JSON.parse(decodeURIComponent(e)),
-    saveAnswerByValue = (e, t, n = !1) => {
-        if ("office" == e)
-            for (k in answers) delete answers[k];
-        n ? (n = decodeObj(t), answers[e] = n) : answers[e] = t, checkMandatoryFields()
-    console.log(answers)
-    },
-    saveAnswerById = (e, t, n) => {
-        t = document.getElementById(t)?.value;
-        answers[e] = JSON.parse(t), "function" == typeof n && n(), checkMandatoryFields()
-    },
-    officeSelect = document.getElementById("privacy"),
-    appointment = (officeSelect.addEventListener("change", () => {
-        var e = officeSelect?.value,
-            t = officeSelect?.querySelector(`[value="${e}"]`)?.innerText;
-        saveAnswerByValue("office", encodeObject({
-            id: e,
-            name: t
-        }), !0), officeSelect?.value ? (e = new URLSearchParams({
-            id: officeSelect.value
-        }), fetch(window.wpRestApi + "wp/v2/sedi/ufficio/?" + e).then(e => e.json()).then(e => {
-            document.querySelector("#place-cards-wrapper").innerHTML = '<legend class="visually-hidden">Seleziona un ufficio</legend>';
-            for (const n of e) {
-                var t = {
-                    nome: n.post_title,
-                    indirizzo: n.indirizzo,
-                    apertura: n.apertura,
-                    id: n.identificativo
-                };
-                document.querySelector("#place-cards-wrapper").innerHTML += `
-          <div class="cmp-info-radio radio-card">
-            <div class="card p-3 p-lg-4">
-              <div class="card-header mb-0 p-0">
-                <div class="form-check m-0">
-                    <input
-                    class="radio-input"
-                    name="beneficiaries"
-                    type="radio"
-                    id=${n?.ID}
-                    value='${JSON.stringify(t)}'
-                    onclick="saveAnswerById('place', ${n?.ID}, ${()=>setSelectedPlace()})"
-                    />
-                    <label for=${n?.ID}>
-                    <h3 class="big-title mb-0 pb-0">
-                        ${n?.post_title}
-                    </h3></label
-                    >
-                </div>
-              </div>
-              <div class="card-body p-0">
-                <div class="info-wrapper">
-                  <span class="info-wrapper__label">Indirizzo</span>
-                  <p class="info-wrapper__value">
-                  ${n?.indirizzo}
-                  </p>
-                </div>
-                <div class="info-wrapper">
-                    <span class="info-wrapper__label">Apertura</span>
-                    <p class="info-wrapper__value">
-                    ${n?.apertura}
-                    </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          `
-            }
-            borderCardRadio()
-        }).catch(e => {
-            console.log("err", e)
-        }), fetch(window.wpRestApi + "wp/v2/servizi/ufficio?" + e).then(e => e.json()).then(e => {
-            document.querySelector("#motivo-appuntamento").innerHTML = '<option selected="selected" value="">Seleziona opzione</option>';
-            for (const t of e) document.querySelector("#motivo-appuntamento").innerHTML += `
-          <option value="${t?.ID}">${t?.post_title}</option>
-          `
-        }).catch(e => {
-            console.log("err", e)
-        })) : document.querySelector("#place-cards-wrapper").innerHTML = ""
-    }), document.getElementById("appointment")),
-    setSelectedPlace = (appointment.addEventListener("change", () => {
-        answers.appointment = null, checkMandatoryFields(), fetch(url + (`?month=${appointment?.value}&office=` + answers?.place?.id)).then(e => {
-            if (e.ok) return e.json();
-            throw new Error("HTTP error " + e.status)
-        }).then(e => {
-            e = e[appointment?.value], document.querySelector("#radio-appointment").innerHTML = '<legend class="visually-hidden">Seleziona un giorno e orario</legend>';
-            for (const s of e) {
-                var {
-                    startDate: t,
-                    endDate: n
-                } = s, r = t.split("T")[0], r = new Date(r).toLocaleString([], {
-                    weekday: "long",
-                    day: "2-digit",
-                    month: "long",
-                    year: "numeric"
-                }), a = t + "/" + n, n = encodeObject({
-                    startDate: t,
-                    endDate: n
-                });
-                document.querySelector("#radio-appointment").innerHTML += `
-        <div
-        class="radio-body border-bottom border-light"
-        >
-        <input name="radio" type="radio" id="${a}" onclick="saveAnswerByValue('appointment', '${n}', true)"/>
-        <label for="${a}" class="text-capitalize">${r} ore ${t.split("T")[1]}</label>
-        </div>
-        `
-            }
-        }).catch(e => {
-            console.log("err", e)
-        })
-    }), () => {
-        var e = answers?.place;
-        document.querySelector("#selected-place-card").innerHTML = `  
-  <div class="cmp-info-summary bg-white mb-4 mb-lg-30 p-4">
-  <div class="card">
-      <div
-      class="card-header border-bottom border-light p-0 mb-0 d-flex justify-content-between d-flex justify-content-end"
-      >
-      <h3 class="title-large-semi-bold mb-3">
-        ${e?.nome}
-      </h3>
-      </div>
+  function getValue(id) {
+    var el = getEl(id);
+    return el ? (el.value || '').trim() : '';
+  }
 
-      <div class="card-body p-0">
-      <div class="single-line-info border-light">
-          <div class="text-paragraph-small">Indirizzo</div>
-          <div class="border-light">
-          <p class="data-text">
-            ${e?.indirizzo}
-          </p>
-          </div>
-      </div>
-      <div class="single-line-info border-light">
-          <div class="text-paragraph-small">Apertura</div>
-          <div class="border-light">
-          <p class="data-text">
-            ${e?.apertura}
-          </p>
-          </div>
-      </div>
-      </div>
-      <div class="card-footer p-0"></div>
-  </div>
-  </div>
-</div>
-  `
-    }),
-    serviceSelect = document.getElementById("motivo-appuntamento"),
-    moreDetailsText = (serviceSelect.addEventListener("change", () => {
-        var e = serviceSelect?.value,
-            t = serviceSelect?.querySelector(`[value="${e}"]`)?.innerText;
-        saveAnswerByValue("service", encodeObject({
-            id: e,
-            name: t
-        }), !0)
-    }), document.getElementById("form-details")),
-    nameInput = (moreDetailsText.addEventListener("input", () => {
-        saveAnswerByValue("moreDetails", moreDetailsText?.value)
-    }), document.getElementById("name")),
-    surnameInput = (nameInput.addEventListener("input", () => {
-        saveAnswerByValue("name", nameInput?.value)
-    }), document.getElementById("surname")),
-    emailInput = (surnameInput.addEventListener("input", () => {
-        saveAnswerByValue("surname", surnameInput?.value)
-    }), document.getElementById("email")),
-    getDay = (emailInput.addEventListener("input", () => {
-        saveAnswerByValue("email", emailInput?.value)
-    }), () => {
-        var e = answers?.appointment?.startDate?.split("T")[0];
-        return new Date(e).toLocaleString([], {
-            weekday: "long",
-            day: "2-digit",
-            month: "long",
-            year: "numeric"
-        })
-    }),
-    getHour = () => {
-        var e = answers?.appointment;
-        return [e?.startDate?.split("T")[1], e?.endDate?.split("T")[1]]
-    },
-    setReviews = () => {
-        document.getElementById("review-office").innerHTML = answers?.office?.name, document.getElementById("review-place").innerHTML = answers?.place?.nome, document.getElementById("review-date").innerHTML = getDay(), document.getElementById("review-hour").innerHTML = getHour()[0] + " - " + getHour()[1], document.getElementById("review-service").innerHTML = answers?.service?.name, document.getElementById("review-details").innerHTML = answers?.moreDetails, document.getElementById("review-name").innerHTML = answers?.name, document.getElementById("review-surname").innerHTML = answers?.surname, document.getElementById("review-email").innerHTML = answers?.email
-    },
-    checkMandatoryFields = () => {
-        switch (currentStep) {
-            case 1:
-                answers?.office.id === "privacy-field" ? btnNext.disabled = !1 : btnNext.disabled = !0;
-                break;
-            case 2:
-                answers?.appointment ? btnNext.disabled = !1 : btnNext.disabled = !0;
-                break;
-            case 3:
-                answers?.service && answers?.moreDetails ? btnNext.disabled = !1 : btnNext.disabled = !0;
-                break;
-            case 4:
-                answers?.name && answers?.surname && answers?.email ? btnNext.disabled = !1 : btnNext.disabled = !0
-        }
-    };
-async function successFeedback() {
-    document.getElementById("email-recap").innerText = answers?.email, document.getElementById("date-recap").innerText = ` ${getDay()} dalle ore ${getHour()[0]} alle ore ` + getHour()[1];
-    var e = await getServiceDetail(answers?.service?.id);
-    if (0 < e?._dci_servizio_cosa_serve_list?.length || e?._dci_servizio_cosa_serve_introduzione) {
-        const t = document.getElementById("needed-recap");
-        t.innerHTML = `
-      <p class="font-serif">${e?._dci_servizio_cosa_serve_introduzione}</p>
-    `, 0 < e?._dci_servizio_cosa_serve_list?.length && (t.innerHTML += "<ul>", e._dci_servizio_cosa_serve_list.forEach(e => {
-            t.innerHTML += `<li>${e}</li>`
-        }), t.innerHTML += "</ul>")
+  function setProgress() {
+    var progresses = document.querySelectorAll('[data-progress]');
+    for (var i = 0; i < progresses.length; i++) {
+      progresses[i].classList.add('d-none');
     }
-    document.getElementById("office-recap").innerHTML = `
-    <a
-      href="#"
-      class="text-decoration-none"
-      >${answers?.office?.name}</a
-    >  
-  `, document.getElementById("address-recap").innerHTML = answers?.place?.nome, document.getElementById("form-steps").classList.add("d-none"), document.getElementById("final-step").classList.remove("d-none")
-}
-const confirmAppointment = () => {
-    var e, t = new URLSearchParams;
-    for (e in answers) "object" == typeof answers[e] ? t.append(e, JSON.stringify(answers[e])) : t.append(e, answers[e]);
-    t.append("action", "save_appuntamento"), fetch(urlConfirm, {
-        method: "POST",
-        credentials: "same-origin",
-        headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Cache-Control": "no-cache"
-        },
-        body: t
-    }).then(e => {
-        if (e.ok) return e.json();
-        throw new Error("HTTP error " + e.status)
-    }).then(e => {
-        successFeedback();
-        var t = document.querySelector("#main-container");
-        t && t.scrollIntoView({
-            behavior: "smooth"
-        })
-    }).catch(e => {
-        console.log("err", e)
-    })
-};
-async function getServiceDetail(e) {
-    try {
-        return await fetch(window.wpRestApi + "wp/v2/servizi/" + e).then(e => {
-            if (e.ok) return e.json();
-            throw new Error("HTTP error " + e.status)
-        }).then(e => e?.cmb2?._dci_servizio_box_cosa_serve).catch(e => {
-            console.log("err", e)
-        })
-    } catch (e) {
-        console.error(e)
+    var currentProgress = document.querySelector('[data-progress="' + currentStep + '"]');
+    if (currentProgress) currentProgress.classList.remove('d-none');
+  }
+
+  function showStep(stepNumber) {
+    var node = content.querySelector('[data-steps="' + stepNumber + '"]');
+    if (!node) return;
+    node.classList.remove('d-none');
+    node.classList.add('active');
+  }
+
+  function hideStep(stepNumber) {
+    var node = content.querySelector('[data-steps="' + stepNumber + '"]');
+    if (!node) return;
+    node.classList.add('d-none');
+    node.classList.remove('active');
+  }
+
+  function validateEmail(email) {
+    var regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return regex.test(email);
+  }
+
+  function updateNextState() {
+    if (!btnNext) return;
+
+    if (currentStep === 1) {
+      var privacy = getEl('privacy');
+      btnNext.disabled = !(privacy && privacy.checked);
+      return;
     }
-}
+
+    if (currentStep === 2) {
+      var place = getValue('luogo-disservizio');
+      var service = getValue('motivo-appuntamento');
+      var title = getValue('title');
+      var details = getValue('details');
+      btnNext.disabled = !(place && service && title && details);
+      return;
+    }
+
+    if (currentStep === 3) {
+      btnNext.disabled = false;
+      return;
+    }
+
+    if (currentStep === 4) {
+      var name = getValue('name');
+      var surname = getValue('surname');
+      var email = getValue('email');
+      btnNext.disabled = !(name && surname && email && validateEmail(email));
+      return;
+    }
+
+    btnNext.disabled = false;
+  }
+
+  function getSelectedText(selectId) {
+    var select = getEl(selectId);
+    if (!select || select.selectedIndex < 0) return '';
+    return select.options[select.selectedIndex].text || '';
+  }
+
+  function submitReport() {
+    var title = getValue('title');
+    var details = getValue('details');
+    var name = getValue('name');
+    var surname = getValue('surname');
+    var email = getValue('email');
+    var placeText = getSelectedText('luogo-disservizio');
+    var serviceText = getSelectedText('motivo-appuntamento');
+
+    var fullDetails = [
+      'Titolo: ' + title,
+      'Luogo: ' + placeText,
+      'Tipologia disservizio: ' + serviceText,
+      'Dettagli: ' + details
+    ].join('\n');
+
+    var url = (typeof urlConfirm !== 'undefined' && Array.isArray(urlConfirm)) ? urlConfirm[0] : urlConfirm;
+    var body = new URLSearchParams();
+    body.append('action', 'save_richiesta_assistenza');
+    body.append('nome', name);
+    body.append('cognome', surname);
+    body.append('email', email);
+    body.append('categoria_servizio', '');
+    body.append('servizio', serviceText);
+    body.append('dettagli', fullDetails);
+    body.append('privacyChecked', (getEl('privacy') && getEl('privacy').checked) ? 'true' : 'false');
+
+    return fetch(url, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Cache-Control': 'no-cache'
+      },
+      body: body
+    }).then(function (response) {
+      if (!response.ok) {
+        throw new Error('HTTP error ' + response.status);
+      }
+      return response.json();
+    }).then(function (result) {
+      if (!result || !result.success) {
+        throw new Error('Salvataggio segnalazione non riuscito');
+      }
+
+      var formSteps = getEl('form-steps');
+      if (formSteps) formSteps.classList.add('d-none');
+      if (alertMessage) alertMessage.classList.remove('d-none');
+
+      var mainContainer = document.querySelector('#main-container');
+      if (mainContainer) {
+        mainContainer.scrollIntoView({ behavior: 'smooth' });
+      }
+    });
+  }
+
+  function openNext() {
+    if (!btnNext || !btnBack) return;
+
+    if (currentStep >= steps.length) {
+      btnNext.disabled = true;
+      submitReport().catch(function (err) {
+        console.error(err);
+        btnNext.disabled = false;
+      });
+      return;
+    }
+
+    hideStep(currentStep);
+    currentStep += 1;
+    showStep(currentStep);
+
+    btnBack.disabled = currentStep === 1;
+
+    var nextLabel = btnNext.querySelector('span');
+    if (nextLabel) {
+      nextLabel.innerHTML = currentStep === steps.length ? 'Invia' : 'Avanti';
+    }
+
+    setProgress();
+    updateNextState();
+  }
+
+  function backPrevious() {
+    if (!btnNext || !btnBack || currentStep === 1) return;
+
+    hideStep(currentStep);
+    currentStep -= 1;
+    showStep(currentStep);
+
+    btnBack.disabled = currentStep === 1;
+
+    var nextLabel = btnNext.querySelector('span');
+    if (nextLabel) nextLabel.innerHTML = 'Avanti';
+
+    setProgress();
+    updateNextState();
+  }
+
+  btnNext.addEventListener('click', openNext);
+  btnBack.addEventListener('click', backPrevious);
+
+  var fields = [
+    'privacy',
+    'luogo-disservizio',
+    'motivo-appuntamento',
+    'title',
+    'details',
+    'name',
+    'surname',
+    'email'
+  ];
+
+  for (var i = 0; i < fields.length; i++) {
+    var el = getEl(fields[i]);
+    if (!el) continue;
+
+    if (el.tagName === 'SELECT' || el.type === 'checkbox') {
+      el.addEventListener('change', updateNextState);
+    } else {
+      el.addEventListener('input', updateNextState);
+    }
+  }
+
+  setProgress();
+  updateNextState();
+})();

--- a/inc/actions.php
+++ b/inc/actions.php
@@ -323,6 +323,17 @@ function dci_admin_bar_customize_header() {
         );
     }
 
+    if (current_user_can('edit_posts') && post_type_exists('richiesta_assistenza')) {
+        $wp_admin_bar->add_menu(
+            array(
+                'parent' => 'design-comuni',
+                'id'     => 'dci-segnalazioni-disservizio',
+                'title'  => __('Segnalazioni disservizio', 'design_comuni_italia'),
+                'href'   => admin_url('edit.php?post_type=richiesta_assistenza'),
+            )
+        );
+    }
+
 }
 add_action( 'admin_bar_menu', 'dci_admin_bar_customize_header', -10 );
 
@@ -412,5 +423,4 @@ function dci_edit_permission_check() {
 
 }
 add_filter( 'admin_head', 'dci_edit_permission_check', 1, 4 );
-
 

--- a/inc/admin/dci_richiesta_assistenza.php
+++ b/inc/admin/dci_richiesta_assistenza.php
@@ -29,7 +29,9 @@ function dci_register_post_type_richiesta_assistenza() {
         'menu_position'      => 5,
         'menu_icon'          => 'dashicons-media-spreadsheet',
         'has_archive'        => false,
-        'capability_type'    => array('richiesta_assistenza', 'richieste_assistenza'),
+        // Usiamo capability standard "post" per rendere il menu visibile agli utenti admin/editor
+        // senza dover assegnare capability personalizzate aggiuntive.
+        'capability_type'    => 'post',
         'capabilities'       => array(
             'create_posts' => 'do_not_allow'
         ),
@@ -209,4 +211,3 @@ add_action( 'do_meta_boxes', 'dci_richiesta_assistenza_remove_publish_mbox', 10,
 function dci_richiesta_assistenza_remove_publish_mbox($post_type, $position, $post){
     remove_meta_box('submitdiv','richiesta_assistenza','side');
 }
-

--- a/inc/admin/options/opzioni_comune.php
+++ b/inc/admin/options/opzioni_comune.php
@@ -151,6 +151,12 @@ function dci_register_comune_options(){
         'desc' => __( 'Utilizzare questo campo per specificare il link alla pagina prenota appuntamento'),
         'type' => 'text'
     ));
+    $header_options->add_field( array(
+        'id'    => $prefix . 'email_prenota_appuntamento',
+        'name' => __('E-mail notifiche prenota appuntamento', 'design_comuni_italia' ),
+        'desc' => __( 'Indirizzo e-mail che riceve le notifiche delle nuove richieste di prenotazione appuntamento (se vuoto, viene usata la e-mail principale).'),
+        'type' => 'text_email'
+    ));
 
 
     

--- a/inc/backend-template.php
+++ b/inc/backend-template.php
@@ -5,11 +5,7 @@
 // includo i singoli file di template di backend
 foreach (glob(get_template_directory() ."/inc/admin/*.php") as $filename)
 {
-    if (
-    	!str_contains($filename, 'richiesta_assistenza')
-    ) {
 	require $filename;
-	}
 }
 
 //includo comuni_config.php

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -84,6 +84,207 @@ function dci_register_servizi_ufficio_route() {
 add_action('rest_api_init', 'dci_register_servizi_ufficio_route');
 
 /**
+ * Espone gli slot prenotabili costruiti dall'orario associato all'Unità organizzativa.
+ */
+function dci_register_appuntamenti_ufficio_route() {
+    register_rest_route('wp/v2', '/appuntamenti/ufficio/', array(
+        'methods' => 'GET',
+        'callback' => 'dci_get_appuntamenti_ufficio'
+    ));
+}
+add_action('rest_api_init', 'dci_register_appuntamenti_ufficio_route');
+
+/**
+ * Genera gli slot appuntamento del mese richiesto a partire dall'orario UO.
+ *
+ * @param WP_REST_Request $request
+ * @return array
+ */
+function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
+    $office_id = absint($request->get_param('id'));
+    $month = absint($request->get_param('month'));
+    $year = absint($request->get_param('year'));
+
+    if ($office_id <= 0) {
+        return array(
+            "error" => array(
+                "code" => 400,
+                "message" => "Parametro id mancante o non valido."
+            )
+        );
+    }
+
+    if ($month < 1 || $month > 12) {
+        $month = (int) wp_date('n');
+    }
+    if ($year < 1) {
+        $year = (int) wp_date('Y');
+    }
+
+    $orario_id = absint(dci_get_meta('orario_uo', '_dci_unita_organizzativa_', $office_id));
+    if ($orario_id <= 0) {
+        return array();
+    }
+
+    $prefix = '_dci_orario_';
+    $data_inizio_raw = get_post_meta($orario_id, $prefix . 'data_inizio', true);
+    $data_fine_raw = get_post_meta($orario_id, $prefix . 'data_fine', true);
+
+    $data_inizio = DateTime::createFromFormat('d-m-Y', $data_inizio_raw) ?: null;
+    $data_fine = DateTime::createFromFormat('d-m-Y', $data_fine_raw) ?: null;
+    if (!$data_inizio || !$data_fine) {
+        return array();
+    }
+
+    $first_day = DateTime::createFromFormat('Y-n-j H:i:s', $year . '-' . $month . '-1 00:00:00');
+    $last_day = clone $first_day;
+    $last_day->modify('last day of this month')->setTime(23, 59, 59);
+
+    $slot_duration = 45; // minuti
+    $giorni_map = array(
+        1 => 'lun',
+        2 => 'mar',
+        3 => 'mer',
+        4 => 'gio',
+        5 => 'ven',
+        6 => 'sab',
+        7 => 'dom',
+    );
+
+    $slots = array();
+    $cursor = clone $first_day;
+    $now = new DateTime('now', wp_timezone());
+
+    while ($cursor <= $last_day) {
+        if ($cursor >= $data_inizio && $cursor <= $data_fine && !dci_is_festivo_nazionale($cursor)) {
+            $weekday = (int) $cursor->format('N');
+            $day_prefix = $giorni_map[$weekday];
+
+            $mattina = get_post_meta($orario_id, $prefix . $day_prefix . '_mattina', true);
+            $pomeriggio = get_post_meta($orario_id, $prefix . $day_prefix . '_pomeriggio', true);
+
+            $fasce = array_filter(array($mattina, $pomeriggio));
+            foreach ($fasce as $fascia) {
+                $parsed = dci_parse_orario_range($fascia);
+                if (!$parsed) {
+                    continue;
+                }
+
+                list($start_h, $start_m, $end_h, $end_m) = $parsed;
+                $slot_start = (clone $cursor)->setTime($start_h, $start_m, 0);
+                $slot_end_limit = (clone $cursor)->setTime($end_h, $end_m, 0);
+
+                while ((clone $slot_start)->modify('+' . $slot_duration . ' minutes') <= $slot_end_limit) {
+                    $slot_end = (clone $slot_start)->modify('+' . $slot_duration . ' minutes');
+                    if ($slot_start <= $now) {
+                        $slot_start = $slot_end;
+                        continue;
+                    }
+
+                    $slots[] = array(
+                        'startDate' => $slot_start->format('Y-m-d\TH:i'),
+                        'endDate' => $slot_end->format('Y-m-d\TH:i'),
+                    );
+                    $slot_start = $slot_end;
+                }
+            }
+        }
+
+        $cursor->modify('+1 day')->setTime(0, 0, 0);
+    }
+
+    return $slots;
+}
+
+/**
+ * Verifica se una data ricade in un giorno festivo nazionale.
+ *
+ * @param DateTime $date
+ * @return bool
+ */
+function dci_is_festivo_nazionale(DateTime $date) {
+    // Tutte le domeniche sono giorni festivi a livello nazionale.
+    if ((int) $date->format('N') === 7) {
+        return true;
+    }
+
+    $fixed_holidays = array(
+        '01-01', // Capodanno
+        '01-06', // Epifania
+        '04-25', // Liberazione
+        '05-01', // Festa del Lavoro
+        '06-02', // Festa della Repubblica
+        '08-15', // Ferragosto
+        '11-01', // Ognissanti
+        '12-08', // Immacolata
+        '12-25', // Natale
+        '12-26', // Santo Stefano
+    );
+    $day_month = $date->format('m-d');
+    if (in_array($day_month, $fixed_holidays, true)) {
+        return true;
+    }
+
+    // Festività regionale applicata solo ai comuni con regione impostata su Sicilia.
+    if (dci_is_regione_sicilia() && $day_month === '05-15') {
+        return true;
+    }
+
+    $year = (int) $date->format('Y');
+    $easter_timestamp = easter_date($year);
+    $easter = (new DateTime('@' . $easter_timestamp))->setTimezone(wp_timezone());
+    $easter_monday = (clone $easter)->modify('+1 day');
+
+    return $date->format('Y-m-d') === $easter->format('Y-m-d') ||
+        $date->format('Y-m-d') === $easter_monday->format('Y-m-d');
+}
+
+/**
+ * Verifica se il comune configurato appartiene alla Regione Sicilia.
+ *
+ * @return bool
+ */
+function dci_is_regione_sicilia() {
+    $nome_regione = dci_get_option('nome_regione');
+    if (!is_string($nome_regione)) {
+        return false;
+    }
+
+    return sanitize_title($nome_regione) === 'sicilia';
+}
+
+/**
+ * Parsing range orario "08:30 - 12:30".
+ *
+ * @param string $range
+ * @return array|null
+ */
+function dci_parse_orario_range($range) {
+    if (!is_string($range) || trim($range) === '') {
+        return null;
+    }
+
+    if (!preg_match('/^\s*(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})\s*$/', $range, $matches)) {
+        return null;
+    }
+
+    $start_h = (int) $matches[1];
+    $start_m = (int) $matches[2];
+    $end_h = (int) $matches[3];
+    $end_m = (int) $matches[4];
+
+    if ($start_h > 23 || $end_h > 23 || $start_m > 59 || $end_m > 59) {
+        return null;
+    }
+
+    if ($end_h < $start_h || ($end_h === $start_h && $end_m <= $start_m)) {
+        return null;
+    }
+
+    return array($start_h, $start_m, $end_h, $end_m);
+}
+
+/**
  * restituisce i servizi che sono disponibili presso l'Unità Organizzativa passata come parametro (id o title)
  * @param WP_REST_Request $request
  * @return array[]
@@ -207,7 +408,8 @@ function dci_save_richiesta_assistenza(){
         $ticket_title = 'ticket_'.$timestamp;
         $postId = wp_insert_post(array(
             'post_type' => 'richiesta_assistenza',
-            'post_title' =>  $ticket_title
+            'post_title' =>  $ticket_title,
+            'post_status' => 'publish'
         ));
     }
 
@@ -263,6 +465,8 @@ add_action("wp_ajax_nopriv_save_richiesta_assistenza" , "dci_save_richiesta_assi
 function dci_save_appuntamento(){
 
     $params = json_decode(json_encode($_POST), true);
+    $postId = 0;
+    $appuntamento_title = '';
 
     date_default_timezone_set('Europe/Rome');
     $data = date('Y-m-d\TH:i:s');
@@ -273,7 +477,8 @@ function dci_save_appuntamento(){
 
         $postId = wp_insert_post(array(
             'post_type' => 'appuntamento',
-            'post_title' =>  $appuntamento_title
+            'post_title' =>  $appuntamento_title,
+            'post_status' => 'publish'
         ));
     }
 
@@ -319,9 +524,12 @@ function dci_save_appuntamento(){
         update_post_meta($postId, '_dci_appuntamento_data_ora_fine_appuntamento',  $endDate);
     }
 
+    $mail_sent = dci_send_appuntamento_notification($postId, $params, $data);
+
     echo json_encode(array(
         "success" => true,
         "message" => 'Contenuto creato con successo: '.$postId,
+        "mail_sent" => $mail_sent,
         "appuntamento" => array(
             "id" => $postId),
         "title" => $appuntamento_title
@@ -333,3 +541,80 @@ function dci_save_appuntamento(){
 
 add_action("wp_ajax_save_appuntamento" , "dci_save_appuntamento");
 add_action("wp_ajax_nopriv_save_appuntamento" , "dci_save_appuntamento");
+
+/**
+ * Invia una notifica e-mail alla creazione di una richiesta appuntamento.
+ *
+ * @param int    $postId
+ * @param array  $params
+ * @param string $data
+ * @return bool
+ */
+function dci_send_appuntamento_notification($postId, $params, $data) {
+    if (empty($postId)) {
+        return false;
+    }
+
+    $to = dci_get_option('email_prenota_appuntamento');
+    if (empty($to)) {
+        $to = dci_get_option('email_principale');
+    }
+    if (empty($to)) {
+        $to = get_option('admin_email');
+    }
+    if (!is_email($to)) {
+        return false;
+    }
+
+    $service_name = '';
+    if (array_key_exists('service', $params) && $params['service'] != "null") {
+        $service_obj = json_decode(stripslashes($params['service']), true);
+        $service_name = $service_obj['name'] ?? '';
+    }
+
+    $office_name = '';
+    if (array_key_exists('office', $params) && $params['office'] != "null") {
+        $office_obj = json_decode(stripslashes($params['office']), true);
+        $office_name = $office_obj['name'] ?? '';
+    }
+
+    $appointment_start = '';
+    $appointment_end = '';
+    if (array_key_exists('appointment', $params) && $params['appointment'] != "null") {
+        $appointment_obj = json_decode(stripslashes($params['appointment']), true);
+        $appointment_start = $appointment_obj['startDate'] ?? '';
+        $appointment_end = $appointment_obj['endDate'] ?? '';
+    }
+
+    $subject = sprintf('[%s] Nuova richiesta prenotazione appuntamento', wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES));
+    $message_lines = array(
+        'È stata creata una nuova richiesta di prenotazione appuntamento.',
+        '',
+        'ID richiesta: ' . $postId,
+        'Data richiesta: ' . $data,
+        'Nome: ' . ($params['name'] ?? ''),
+        'Cognome: ' . ($params['surname'] ?? ''),
+        'Email richiedente: ' . ($params['email'] ?? ''),
+        'Ufficio: ' . $office_name,
+        'Servizio: ' . $service_name,
+        'Dettagli: ' . ($params['moreDetails'] ?? ''),
+        'Inizio appuntamento: ' . $appointment_start,
+        'Fine appuntamento: ' . $appointment_end,
+        '',
+        'Link nel pannello admin: ' . admin_url('post.php?post=' . $postId . '&action=edit'),
+    );
+    $message = implode("\n", $message_lines);
+    $headers = array('Content-Type: text/plain; charset=UTF-8');
+
+    $from = dci_get_option('email_principale');
+    if (is_email($from)) {
+        $headers[] = 'From: ' . wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES) . ' <' . $from . '>';
+    }
+
+    $requester_email = $params['email'] ?? '';
+    if (is_email($requester_email)) {
+        $headers[] = 'Reply-To: ' . $requester_email;
+    }
+
+    return wp_mail($to, $subject, $message, $headers);
+}

--- a/template-parts/prenotazione/content.php
+++ b/template-parts/prenotazione/content.php
@@ -1,7 +1,19 @@
 <?php
     $uffici = get_posts(array(
         'posts_per_page' => -1,
-        'post_type' => 'unita_organizzativa'
+        'post_type' => 'unita_organizzativa',
+        'meta_query' => array(
+            'relation' => 'AND',
+            array(
+                'key' => '_dci_unita_organizzativa_orario_uo',
+                'compare' => 'EXISTS',
+            ),
+            array(
+                'key' => '_dci_unita_organizzativa_orario_uo',
+                'value' => '',
+                'compare' => '!=',
+            ),
+        ),
     ));
 
     $months = array();
@@ -13,6 +25,18 @@
         $currentMonth++;
     }
 ?>
+
+<style>
+    #radio-appointment {
+        max-height: 420px;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #radio-appointment .radio-body label {
+        overflow-wrap: anywhere;
+    }
+</style>
 
 <div class="it-page-sections-container">
 

--- a/template-parts/segnalazione/content.php
+++ b/template-parts/segnalazione/content.php
@@ -62,10 +62,10 @@
                 </div>
                 <div class="card-body p-0">
                     <div class="select-wrapper p-0 mt-1 select-partials">
-                        <label for="appointment" class="visually-hidden">
+                        <label for="luogo-disservizio" class="visually-hidden">
                             Indica il luogo del disservizio
                         </label>
-                        <select id="appointment" class="">
+                        <select id="luogo-disservizio" class="">
                             <option selected="selected" value="">
                                 Indica il luogo del disservizio
                             </option>
@@ -105,7 +105,7 @@
                         <label for="motivo-appuntamento" class="visually-hidden">
                             Tipologia di Disservizio
                         </label>
-                        <select id="appointment" class="">
+                        <select id="motivo-appuntamento" class="">
                             <option selected="selected" value="">
                                 Tipologia di Disservizio
                             </option>
@@ -135,95 +135,14 @@
             </div>
         </div>
         <div class="cmp-card">
-      <div class="card has-bkg-grey shadow-sm">
-        <div class="card-header border-0 p-0 mb-lg-30 m-0">
-          <div class="d-flex">
-                <h2 class="title-xxlarge mb-1">Autore della segnalazione</h2>
-          </div>
-          <p class="subtitle-small mb-0">Informazione su di te</p>
-    
-    
-    
-    
+            <div class="card has-bkg-grey shadow-sm p-big">
+                <div class="card-body p-0">
+                    <p class="subtitle-small mb-0">
+                        I dati del richiedente verranno inseriti nel passaggio successivo.
+                    </p>
+                </div>
+            </div>
         </div>
-        <div class="card-body p-0">
-          
-                        <div class="cmp-info-button-card mt-3">
-                          <div class="card p-3 p-lg-4">
-                            <div class="card-body p-0">
-                              <h3 class="big-title mb-0">Mario Rossi</h3>
-                        
-                        
-                        
-                        
-                              <p class="card-info">Codice Fiscale <br> <span>GLABNC72H25H501Y</span></p>
-                        
-                        
-                              <div class="accordion-item">
-                                <div class="accordion-header" id="heading-collapse-parents">
-                                  <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-parents" aria-expanded="true" aria-controls="collapse-parents" data-focus-mouse="false">
-                                    <span class="d-flex align-items-center">
-                                    Mostra tutto
-                                      <svg class="icon icon-primary icon-sm">
-                                        <use href="../assets/bootstrap-italia/dist/svg/sprites.svg#it-expand"></use>
-                                      </svg>
-                                    </span>
-                                  </button>
-                              
-                              
-                                </div>
-                                <div id="collapse-parents" class="accordion-collapse collapse show" role="region" style="">
-                                  <div class="accordion-body p-0">
-                                    <div class="cmp-info-summary bg-white has-border">
-                                      <div class="card">
-                                    
-                                        <div class="card-header border-bottom border-light p-0 mb-0 d-flex justify-content-between d-flex justify-content-end">
-                                          <h4 class="title-large-semi-bold mb-3">Contatti</h4>
-                                          <a href="#" class="d-none text-decoration-none"><span class="text-button-sm-semi t-primary">Modifica</span></a>
-                                        </div>
-                                    
-                                        <div class="card-body p-0">
-                                          <div class="single-line-info border-light">
-                                            <div class="text-paragraph-small">Telefono</div>
-                                            <div class="border-light">
-                                              <p class="data-text">
-                                                +39 331 1234567
-                                              </p>
-                                    
-                                    
-                                    
-                                            </div>
-                                          </div>
-                                          <div class="single-line-info border-light">
-                                            <div class="text-paragraph-small">Email</div>
-                                            <div class="border-light">
-                                              <p class="data-text">
-                                                mario.rossi@gmail.com
-                                              </p>
-                                    
-                                    
-                                    
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div class="card-footer p-0 d-none">
-                                        </div>
-                                      </div>
-                                    </div>    </div>
-                                </div>
-                              </div>
-                        
-                        
-                        
-                        
-                        
-                        
-                        
-                            </div>
-                          </div>
-                        </div>    </div>
-      </div>
-    </div>
     </section>
 
     <!-- Step 3 -->


### PR DESCRIPTION
### Motivation
- Provide a REST endpoint that builds appointment slots from unit schedule and make the frontend fetch robustly consume it. 
- Simplify and harden the client-side multi-step flows for reporting (`segnalazione`) and booking, adding validation and better empty-state handling. 
- Surface the assistance tickets in the admin bar and ensure notifications and visibility for created appointments and tickets. 

### Description
- Adds a new REST route `wp/v2/appuntamenti/ufficio/` with handler `dci_get_appuntamenti_ufficio` that computes monthly bookable slots from UO schedules, skips national/regional holidays, parses time ranges via `dci_parse_orario_range`, and exposes these slots as `startDate`/`endDate` pairs. 
- Refactors booking JS to build query params with `URLSearchParams`, call the new REST endpoint (`window.wpRestApi + "wp/v2/appuntamenti/ufficio/?"`), handle non-array/empty responses and show a user-friendly message when no slots are available. 
- Rewrites the segnalazione multi-step client logic (IIFE) to a clearer structure with step navigation, input validation (including email regex), progress updates, and a `submitReport` routine posting `save_richiesta_assistenza` via `fetch`. 
- Adds admin and post-type improvements: exposes a "Segnalazioni disservizio" admin-bar item when the CPT exists, changes `richiesta_assistenza` capabilities to use standard `post` type so editors/admins see the menu, ensures new `appuntamento` and `richiesta_assistenza` posts are created as `publish`, and adds an option `email_prenota_appuntamento` for notification delivery. 
- Implements server-side email notifications for new appointments in `dci_send_appuntamento_notification` and returns `mail_sent` in the `save_appuntamento` response. 
- Template and UI tweaks: filter offices in the prenotazione template to only those with an associated schedule, add styling for the radio list scroll area, and consolidate several ID/name changes in segnalazione templates to match the new JS. 

### Testing
- Performed PHP syntax checks with `php -l` on modified PHP files and fixed issues detected; all checked files passed linting. 
- Performed basic JavaScript syntax/static checks (ESLint or equivalent) on changed JS bundles; no syntax errors reported. 
- Executed a smoke test of the new REST endpoint with `curl` on the development environment to confirm it returns JSON and responds to `id`, `month` and `year` query params (endpoint returned a 200 JSON response).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c253f15ac483329179896ef4f37fd3)