### PR TITLE
External portal integration, appointments REST, notifications and forms improvements

### DIFF
--- a/assets-src/js/booking.js
+++ b/assets-src/js/booking.js
@@ -262,8 +262,13 @@ appointment.addEventListener("change", () => {
   answers.appointment = null;
   checkMandatoryFields();
 
-  // modificare l'url se si vuole integrare con un servizio esterno
-  fetch(url + `?month=${appointment?.value}&office=${answers?.place?.id}`)
+  const urlParam = new URLSearchParams({
+    id: answers?.office?.id,
+    month: appointment?.value,
+    year: new Date().getFullYear(),
+  });
+
+  fetch(`${window.wpRestApi}wp/v2/appuntamenti/ufficio/?${urlParam}`)
     .then((response) => {
       if (!response.ok) {
         throw new Error("HTTP error " + response.status);
@@ -271,9 +276,17 @@ appointment.addEventListener("change", () => {
       return response.json();
     })
     .then((data) => {
-      data = data[appointment?.value]
+      data = Array.isArray(data) ? data : data?.[appointment?.value] || [];
       document.querySelector("#radio-appointment").innerHTML =
         '<legend class="visually-hidden">Seleziona un giorno e orario</legend>';
+
+      if (!data.length) {
+        document.querySelector("#radio-appointment").innerHTML += `
+        <p class="mt-2 mb-0">Nessun appuntamento disponibile per il mese selezionato.</p>
+        `;
+        return;
+      }
+
       for (const dates of data) {
         const { startDate, endDate } = dates;
         const startDay = startDate.split("T")[0];

--- a/assets/js/booking.js
+++ b/assets/js/booking.js
@@ -36,14 +36,16 @@ function borderCardRadio(){var t=document.querySelectorAll(".radio-card");docume
           </div>
           `}borderCardRadio()}).catch(e=>{console.log("err",e)}),fetch(window.wpRestApi+"wp/v2/servizi/ufficio?"+e).then(e=>e.json()).then(e=>{document.querySelector("#motivo-appuntamento").innerHTML='<option selected="selected" value="">Seleziona opzione</option>';for(const t of e)document.querySelector("#motivo-appuntamento").innerHTML+=`
           <option value="${t?.ID}">${t?.post_title}</option>
-          `}).catch(e=>{console.log("err",e)})):document.querySelector("#place-cards-wrapper").innerHTML=""}),document.getElementById("appointment")),setSelectedPlace=(appointment.addEventListener("change",()=>{answers.appointment=null,checkMandatoryFields(),fetch(url+(`?month=${appointment?.value}&office=`+answers?.place?.id)).then(e=>{if(e.ok)return e.json();throw new Error("HTTP error "+e.status)}).then(e=>{e=e[appointment?.value],document.querySelector("#radio-appointment").innerHTML='<legend class="visually-hidden">Seleziona un giorno e orario</legend>';for(const s of e){var{startDate:t,endDate:n}=s,r=t.split("T")[0],r=new Date(r).toLocaleString([],{weekday:"long",day:"2-digit",month:"long",year:"numeric"}),a=t+"/"+n,n=encodeObject({startDate:t,endDate:n});document.querySelector("#radio-appointment").innerHTML+=`
+          `}).catch(e=>{console.log("err",e)})):document.querySelector("#place-cards-wrapper").innerHTML=""}),document.getElementById("appointment")),setSelectedPlace=(appointment.addEventListener("change",()=>{answers.appointment=null,checkMandatoryFields();var e=new URLSearchParams({id:answers?.office?.id,month:appointment?.value,year:(new Date).getFullYear()});fetch(window.wpRestApi+"wp/v2/appuntamenti/ufficio/?"+e).then(e=>{if(e.ok)return e.json();throw new Error("HTTP error "+e.status)}).then(e=>{if(e=Array.isArray(e)?e:e?.[appointment?.value]||[],document.querySelector("#radio-appointment").innerHTML='<legend class="visually-hidden">Seleziona un giorno e orario</legend>',e.length)for(const s of e){var{startDate:t,endDate:n}=s,r=t.split("T")[0],r=new Date(r).toLocaleString([],{weekday:"long",day:"2-digit",month:"long",year:"numeric"}),a=t+"/"+n,n=encodeObject({startDate:t,endDate:n});document.querySelector("#radio-appointment").innerHTML+=`
         <div
         class="radio-body border-bottom border-light"
         >
         <input name="radio" type="radio" id="${a}" onclick="saveAnswerByValue('appointment', '${n}', true)"/>
         <label for="${a}" class="text-capitalize">${r} ore ${t.split("T")[1]}</label>
         </div>
-        `}}).catch(e=>{console.log("err",e)})}),()=>{var e=answers?.place;document.querySelector("#selected-place-card").innerHTML=`  
+        `}else document.querySelector("#radio-appointment").innerHTML+=`
+        <p class="mt-2 mb-0">Nessun appuntamento disponibile per il mese selezionato.</p>
+        `}).catch(e=>{console.log("err",e)})}),()=>{var e=answers?.place;document.querySelector("#selected-place-card").innerHTML=`  
   <div class="cmp-info-summary bg-white mb-4 mb-lg-30 p-4">
   <div class="card">
       <div

--- a/assets/js/segnalazione.js
+++ b/assets/js/segnalazione.js
@@ -1,305 +1,214 @@
-function borderCardRadio() {
-    var t = document.querySelectorAll(".radio-card");
-    document.querySelectorAll(".radio-input").forEach(function(e, n) {
-        e.addEventListener("change", function() {
-            t.forEach(function(e, t) {
-                n == t ? e.classList.add("has-border-green") : e.classList.remove("has-border-green")
-            })
-        })
-    })
-}
-var content = document.querySelector(".section-wrapper"),
-    currentStep = 1,
-    navscroll = document.querySelector('[data-index="'.concat(currentStep, '"]')),
-    progressBar = document.querySelector('[data-progress="'.concat(currentStep, '"]')),
-    btnNext = content.querySelector(".btn-next-step"),
-    btnBack = content.querySelector(".btn-back-step");
+(function () {
+  var content = document.querySelector('.section-wrapper');
+  if (!content) return;
 
-function pageSteps() {
-    var e;
-    content && (e = content.querySelectorAll(".saveBtn"), navscroll.classList.add("d-lg-block"), progressBar.classList.remove("d-none"), e.forEach(function(e) {
-        e.classList.add("invisible")
-    }), btnNext && btnNext.addEventListener("click", function() {
-        openNext()
-    }), btnBack) && btnBack.addEventListener("click", function() {
-        backPrevious()
-    })
-}
+  var steps = Array.prototype.slice.call(content.querySelectorAll('[data-steps]'));
+  var btnNext = content.querySelector('.btn-next-step');
+  var btnBack = content.querySelector('.btn-back-step');
+  var alertMessage = document.getElementById('alert-message');
+  var currentStep = 1;
 
-function openNext() {
-    btnBack.disabled = !1;
-    var e = content.querySelectorAll(".saveBtn"),
-        t = content.querySelectorAll("[data-steps]"),
-        n = content.querySelector('[data-steps="'.concat(currentStep + 1, '"]')),
-        r = content.querySelector("[data-steps].active");
-    navscroll.classList.remove("d-lg-block"), progressBar.classList.remove("d-block"), progressBar.classList.add("d-none"), currentStep == t.length ? confirmAppointment() : (r.classList.add("d-none"), r.classList.remove("active"), n.classList.add("active"), n.classList.remove("d-none"), currentStep += 1, checkMandatoryFields(), (progressBar = document.querySelector('[data-progress="'.concat(currentStep, '"]'))).classList.add("d-block"), progressBar.classList.remove("d-none"), currentStep < t.length && (navscroll = document.querySelector('[data-index="'.concat(currentStep, '"]'))).classList.add("d-lg-block"), currentStep == t.length && content.classList.remove("offset-lg-1"), currentStep == t.length && (btnNext.disabled = !1, content.querySelector(".steppers-btn-confirm span").innerHTML = "Invia", e.forEach(function(e) {
-        e.classList.remove("invisible"), e.classList.add("visible"), setReviews()
-    })))
-}
+  function getEl(id) {
+    return document.getElementById(id);
+  }
 
-function backPrevious() {
-    btnNext.disabled = !1;
-    var e = content.querySelectorAll(".saveBtn"),
-        t = content.querySelectorAll("[data-steps]"),
-        n = content.querySelector("[data-steps].active"),
-        r = content.querySelector('[data-steps="'.concat(currentStep - 1, '"]'));
-    1 != currentStep && (r.classList.remove("d-none"), r.classList.add("active"), n.classList.add("d-none"), n.classList.remove("active"), navscroll.classList.remove("d-lg-block"), progressBar.classList.add("d-none"), currentStep -= 1, (progressBar = document.querySelector('[data-progress="'.concat(currentStep, '"]'))).classList.toggle("d-none"), content.querySelector(".steppers-btn-confirm span").innerHTML = "Avanti", currentStep < t.length && ((navscroll = document.querySelector('[data-index="'.concat(currentStep, '"]'))).classList.add("d-lg-block"), content.classList.add("offset-lg-1")), currentStep < t.length && e.forEach(function(e) {
-        e.classList.remove("visible"), e.classList.add("invisible")
-    }), 1 == currentStep) && (btnBack.disabled = !0)
-}
-pageSteps();
-const answers = {},
-    encodeObject = e => encodeURIComponent(JSON.stringify(e)),
-    decodeObj = e => JSON.parse(decodeURIComponent(e)),
-    saveAnswerByValue = (e, t, n = !1) => {
-        if ("office" == e)
-            for (k in answers) delete answers[k];
-        n ? (n = decodeObj(t), answers[e] = n) : answers[e] = t, checkMandatoryFields()
-    console.log(answers)
-    },
-    saveAnswerById = (e, t, n) => {
-        t = document.getElementById(t)?.value;
-        answers[e] = JSON.parse(t), "function" == typeof n && n(), checkMandatoryFields()
-    },
-    officeSelect = document.getElementById("privacy"),
-    appointment = (officeSelect.addEventListener("change", () => {
-        var e = officeSelect?.value,
-            t = officeSelect?.querySelector(`[value="${e}"]`)?.innerText;
-        saveAnswerByValue("office", encodeObject({
-            id: e,
-            name: t
-        }), !0), officeSelect?.value ? (e = new URLSearchParams({
-            id: officeSelect.value
-        }), fetch(window.wpRestApi + "wp/v2/sedi/ufficio/?" + e).then(e => e.json()).then(e => {
-            document.querySelector("#place-cards-wrapper").innerHTML = '<legend class="visually-hidden">Seleziona un ufficio</legend>';
-            for (const n of e) {
-                var t = {
-                    nome: n.post_title,
-                    indirizzo: n.indirizzo,
-                    apertura: n.apertura,
-                    id: n.identificativo
-                };
-                document.querySelector("#place-cards-wrapper").innerHTML += `
-          <div class="cmp-info-radio radio-card">
-            <div class="card p-3 p-lg-4">
-              <div class="card-header mb-0 p-0">
-                <div class="form-check m-0">
-                    <input
-                    class="radio-input"
-                    name="beneficiaries"
-                    type="radio"
-                    id=${n?.ID}
-                    value='${JSON.stringify(t)}'
-                    onclick="saveAnswerById('place', ${n?.ID}, ${()=>setSelectedPlace()})"
-                    />
-                    <label for=${n?.ID}>
-                    <h3 class="big-title mb-0 pb-0">
-                        ${n?.post_title}
-                    </h3></label
-                    >
-                </div>
-              </div>
-              <div class="card-body p-0">
-                <div class="info-wrapper">
-                  <span class="info-wrapper__label">Indirizzo</span>
-                  <p class="info-wrapper__value">
-                  ${n?.indirizzo}
-                  </p>
-                </div>
-                <div class="info-wrapper">
-                    <span class="info-wrapper__label">Apertura</span>
-                    <p class="info-wrapper__value">
-                    ${n?.apertura}
-                    </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          `
-            }
-            borderCardRadio()
-        }).catch(e => {
-            console.log("err", e)
-        }), fetch(window.wpRestApi + "wp/v2/servizi/ufficio?" + e).then(e => e.json()).then(e => {
-            document.querySelector("#motivo-appuntamento").innerHTML = '<option selected="selected" value="">Seleziona opzione</option>';
-            for (const t of e) document.querySelector("#motivo-appuntamento").innerHTML += `
-          <option value="${t?.ID}">${t?.post_title}</option>
-          `
-        }).catch(e => {
-            console.log("err", e)
-        })) : document.querySelector("#place-cards-wrapper").innerHTML = ""
-    }), document.getElementById("appointment")),
-    setSelectedPlace = (appointment.addEventListener("change", () => {
-        answers.appointment = null, checkMandatoryFields(), fetch(url + (`?month=${appointment?.value}&office=` + answers?.place?.id)).then(e => {
-            if (e.ok) return e.json();
-            throw new Error("HTTP error " + e.status)
-        }).then(e => {
-            e = e[appointment?.value], document.querySelector("#radio-appointment").innerHTML = '<legend class="visually-hidden">Seleziona un giorno e orario</legend>';
-            for (const s of e) {
-                var {
-                    startDate: t,
-                    endDate: n
-                } = s, r = t.split("T")[0], r = new Date(r).toLocaleString([], {
-                    weekday: "long",
-                    day: "2-digit",
-                    month: "long",
-                    year: "numeric"
-                }), a = t + "/" + n, n = encodeObject({
-                    startDate: t,
-                    endDate: n
-                });
-                document.querySelector("#radio-appointment").innerHTML += `
-        <div
-        class="radio-body border-bottom border-light"
-        >
-        <input name="radio" type="radio" id="${a}" onclick="saveAnswerByValue('appointment', '${n}', true)"/>
-        <label for="${a}" class="text-capitalize">${r} ore ${t.split("T")[1]}</label>
-        </div>
-        `
-            }
-        }).catch(e => {
-            console.log("err", e)
-        })
-    }), () => {
-        var e = answers?.place;
-        document.querySelector("#selected-place-card").innerHTML = `  
-  <div class="cmp-info-summary bg-white mb-4 mb-lg-30 p-4">
-  <div class="card">
-      <div
-      class="card-header border-bottom border-light p-0 mb-0 d-flex justify-content-between d-flex justify-content-end"
-      >
-      <h3 class="title-large-semi-bold mb-3">
-        ${e?.nome}
-      </h3>
-      </div>
+  function getValue(id) {
+    var el = getEl(id);
+    return el ? (el.value || '').trim() : '';
+  }
 
-      <div class="card-body p-0">
-      <div class="single-line-info border-light">
-          <div class="text-paragraph-small">Indirizzo</div>
-          <div class="border-light">
-          <p class="data-text">
-            ${e?.indirizzo}
-          </p>
-          </div>
-      </div>
-      <div class="single-line-info border-light">
-          <div class="text-paragraph-small">Apertura</div>
-          <div class="border-light">
-          <p class="data-text">
-            ${e?.apertura}
-          </p>
-          </div>
-      </div>
-      </div>
-      <div class="card-footer p-0"></div>
-  </div>
-  </div>
-</div>
-  `
-    }),
-    serviceSelect = document.getElementById("motivo-appuntamento"),
-    moreDetailsText = (serviceSelect.addEventListener("change", () => {
-        var e = serviceSelect?.value,
-            t = serviceSelect?.querySelector(`[value="${e}"]`)?.innerText;
-        saveAnswerByValue("service", encodeObject({
-            id: e,
-            name: t
-        }), !0)
-    }), document.getElementById("form-details")),
-    nameInput = (moreDetailsText.addEventListener("input", () => {
-        saveAnswerByValue("moreDetails", moreDetailsText?.value)
-    }), document.getElementById("name")),
-    surnameInput = (nameInput.addEventListener("input", () => {
-        saveAnswerByValue("name", nameInput?.value)
-    }), document.getElementById("surname")),
-    emailInput = (surnameInput.addEventListener("input", () => {
-        saveAnswerByValue("surname", surnameInput?.value)
-    }), document.getElementById("email")),
-    getDay = (emailInput.addEventListener("input", () => {
-        saveAnswerByValue("email", emailInput?.value)
-    }), () => {
-        var e = answers?.appointment?.startDate?.split("T")[0];
-        return new Date(e).toLocaleString([], {
-            weekday: "long",
-            day: "2-digit",
-            month: "long",
-            year: "numeric"
-        })
-    }),
-    getHour = () => {
-        var e = answers?.appointment;
-        return [e?.startDate?.split("T")[1], e?.endDate?.split("T")[1]]
-    },
-    setReviews = () => {
-        document.getElementById("review-office").innerHTML = answers?.office?.name, document.getElementById("review-place").innerHTML = answers?.place?.nome, document.getElementById("review-date").innerHTML = getDay(), document.getElementById("review-hour").innerHTML = getHour()[0] + " - " + getHour()[1], document.getElementById("review-service").innerHTML = answers?.service?.name, document.getElementById("review-details").innerHTML = answers?.moreDetails, document.getElementById("review-name").innerHTML = answers?.name, document.getElementById("review-surname").innerHTML = answers?.surname, document.getElementById("review-email").innerHTML = answers?.email
-    },
-    checkMandatoryFields = () => {
-        switch (currentStep) {
-            case 1:
-                answers?.office.id === "privacy-field" ? btnNext.disabled = !1 : btnNext.disabled = !0;
-                break;
-            case 2:
-                answers?.appointment ? btnNext.disabled = !1 : btnNext.disabled = !0;
-                break;
-            case 3:
-                answers?.service && answers?.moreDetails ? btnNext.disabled = !1 : btnNext.disabled = !0;
-                break;
-            case 4:
-                answers?.name && answers?.surname && answers?.email ? btnNext.disabled = !1 : btnNext.disabled = !0
-        }
-    };
-async function successFeedback() {
-    document.getElementById("email-recap").innerText = answers?.email, document.getElementById("date-recap").innerText = ` ${getDay()} dalle ore ${getHour()[0]} alle ore ` + getHour()[1];
-    var e = await getServiceDetail(answers?.service?.id);
-    if (0 < e?._dci_servizio_cosa_serve_list?.length || e?._dci_servizio_cosa_serve_introduzione) {
-        const t = document.getElementById("needed-recap");
-        t.innerHTML = `
-      <p class="font-serif">${e?._dci_servizio_cosa_serve_introduzione}</p>
-    `, 0 < e?._dci_servizio_cosa_serve_list?.length && (t.innerHTML += "<ul>", e._dci_servizio_cosa_serve_list.forEach(e => {
-            t.innerHTML += `<li>${e}</li>`
-        }), t.innerHTML += "</ul>")
+  function setProgress() {
+    var progresses = document.querySelectorAll('[data-progress]');
+    for (var i = 0; i < progresses.length; i++) {
+      progresses[i].classList.add('d-none');
     }
-    document.getElementById("office-recap").innerHTML = `
-    <a
-      href="#"
-      class="text-decoration-none"
-      >${answers?.office?.name}</a
-    >  
-  `, document.getElementById("address-recap").innerHTML = answers?.place?.nome, document.getElementById("form-steps").classList.add("d-none"), document.getElementById("final-step").classList.remove("d-none")
-}
-const confirmAppointment = () => {
-    var e, t = new URLSearchParams;
-    for (e in answers) "object" == typeof answers[e] ? t.append(e, JSON.stringify(answers[e])) : t.append(e, answers[e]);
-    t.append("action", "save_appuntamento"), fetch(urlConfirm, {
-        method: "POST",
-        credentials: "same-origin",
-        headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Cache-Control": "no-cache"
-        },
-        body: t
-    }).then(e => {
-        if (e.ok) return e.json();
-        throw new Error("HTTP error " + e.status)
-    }).then(e => {
-        successFeedback();
-        var t = document.querySelector("#main-container");
-        t && t.scrollIntoView({
-            behavior: "smooth"
-        })
-    }).catch(e => {
-        console.log("err", e)
-    })
-};
-async function getServiceDetail(e) {
-    try {
-        return await fetch(window.wpRestApi + "wp/v2/servizi/" + e).then(e => {
-            if (e.ok) return e.json();
-            throw new Error("HTTP error " + e.status)
-        }).then(e => e?.cmb2?._dci_servizio_box_cosa_serve).catch(e => {
-            console.log("err", e)
-        })
-    } catch (e) {
-        console.error(e)
+    var currentProgress = document.querySelector('[data-progress="' + currentStep + '"]');
+    if (currentProgress) currentProgress.classList.remove('d-none');
+  }
+
+  function showStep(stepNumber) {
+    var node = content.querySelector('[data-steps="' + stepNumber + '"]');
+    if (!node) return;
+    node.classList.remove('d-none');
+    node.classList.add('active');
+  }
+
+  function hideStep(stepNumber) {
+    var node = content.querySelector('[data-steps="' + stepNumber + '"]');
+    if (!node) return;
+    node.classList.add('d-none');
+    node.classList.remove('active');
+  }
+
+  function validateEmail(email) {
+    var regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return regex.test(email);
+  }
+
+  function updateNextState() {
+    if (!btnNext) return;
+
+    if (currentStep === 1) {
+      var privacy = getEl('privacy');
+      btnNext.disabled = !(privacy && privacy.checked);
+      return;
     }
-}
+
+    if (currentStep === 2) {
+      var place = getValue('luogo-disservizio');
+      var service = getValue('motivo-appuntamento');
+      var title = getValue('title');
+      var details = getValue('details');
+      btnNext.disabled = !(place && service && title && details);
+      return;
+    }
+
+    if (currentStep === 3) {
+      btnNext.disabled = false;
+      return;
+    }
+
+    if (currentStep === 4) {
+      var name = getValue('name');
+      var surname = getValue('surname');
+      var email = getValue('email');
+      btnNext.disabled = !(name && surname && email && validateEmail(email));
+      return;
+    }
+
+    btnNext.disabled = false;
+  }
+
+  function getSelectedText(selectId) {
+    var select = getEl(selectId);
+    if (!select || select.selectedIndex < 0) return '';
+    return select.options[select.selectedIndex].text || '';
+  }
+
+  function submitReport() {
+    var title = getValue('title');
+    var details = getValue('details');
+    var name = getValue('name');
+    var surname = getValue('surname');
+    var email = getValue('email');
+    var placeText = getSelectedText('luogo-disservizio');
+    var serviceText = getSelectedText('motivo-appuntamento');
+
+    var fullDetails = [
+      'Titolo: ' + title,
+      'Luogo: ' + placeText,
+      'Tipologia disservizio: ' + serviceText,
+      'Dettagli: ' + details
+    ].join('\n');
+
+    var url = (typeof urlConfirm !== 'undefined' && Array.isArray(urlConfirm)) ? urlConfirm[0] : urlConfirm;
+    var body = new URLSearchParams();
+    body.append('action', 'save_richiesta_assistenza');
+    body.append('nome', name);
+    body.append('cognome', surname);
+    body.append('email', email);
+    body.append('categoria_servizio', '');
+    body.append('servizio', serviceText);
+    body.append('dettagli', fullDetails);
+    body.append('privacyChecked', (getEl('privacy') && getEl('privacy').checked) ? 'true' : 'false');
+
+    return fetch(url, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Cache-Control': 'no-cache'
+      },
+      body: body
+    }).then(function (response) {
+      if (!response.ok) {
+        throw new Error('HTTP error ' + response.status);
+      }
+      return response.json();
+    }).then(function (result) {
+      if (!result || !result.success) {
+        throw new Error('Salvataggio segnalazione non riuscito');
+      }
+
+      var formSteps = getEl('form-steps');
+      if (formSteps) formSteps.classList.add('d-none');
+      if (alertMessage) alertMessage.classList.remove('d-none');
+
+      var mainContainer = document.querySelector('#main-container');
+      if (mainContainer) {
+        mainContainer.scrollIntoView({ behavior: 'smooth' });
+      }
+    });
+  }
+
+  function openNext() {
+    if (!btnNext || !btnBack) return;
+
+    if (currentStep >= steps.length) {
+      btnNext.disabled = true;
+      submitReport().catch(function (err) {
+        console.error(err);
+        btnNext.disabled = false;
+      });
+      return;
+    }
+
+    hideStep(currentStep);
+    currentStep += 1;
+    showStep(currentStep);
+
+    btnBack.disabled = currentStep === 1;
+
+    var nextLabel = btnNext.querySelector('span');
+    if (nextLabel) {
+      nextLabel.innerHTML = currentStep === steps.length ? 'Invia' : 'Avanti';
+    }
+
+    setProgress();
+    updateNextState();
+  }
+
+  function backPrevious() {
+    if (!btnNext || !btnBack || currentStep === 1) return;
+
+    hideStep(currentStep);
+    currentStep -= 1;
+    showStep(currentStep);
+
+    btnBack.disabled = currentStep === 1;
+
+    var nextLabel = btnNext.querySelector('span');
+    if (nextLabel) nextLabel.innerHTML = 'Avanti';
+
+    setProgress();
+    updateNextState();
+  }
+
+  btnNext.addEventListener('click', openNext);
+  btnBack.addEventListener('click', backPrevious);
+
+  var fields = [
+    'privacy',
+    'luogo-disservizio',
+    'motivo-appuntamento',
+    'title',
+    'details',
+    'name',
+    'surname',
+    'email'
+  ];
+
+  for (var i = 0; i < fields.length; i++) {
+    var el = getEl(fields[i]);
+    if (!el) continue;
+
+    if (el.tagName === 'SELECT' || el.type === 'checkbox') {
+      el.addEventListener('change', updateNextState);
+    } else {
+      el.addEventListener('input', updateNextState);
+    }
+  }
+
+  setProgress();
+  updateNextState();
+})();

--- a/footer.php
+++ b/footer.php
@@ -8,6 +8,17 @@
  *
  * @package Design_Comuni_Italia
  */
+
+$external_only_raw = dci_get_option('ck_portalesoloperusoesterno');
+$is_external_only = in_array(strtolower((string) $external_only_raw), array('1', 'true', 'yes', 'on'), true);
+if ($is_external_only && function_exists('dci_get_external_footer_payload')) {
+    $external_footer = dci_get_external_footer_payload();
+    if (is_array($external_footer) && !empty($external_footer['html'])) {
+        echo $external_footer['html'];
+        wp_footer();
+        return;
+    }
+}
 ?>
 
 <section class="cookiebar fade" aria-label="Gestione dei cookies" aria-live="polite">

--- a/header.php
+++ b/header.php
@@ -14,15 +14,51 @@ $current_group = dci_get_current_group();
 <!doctype html>
 <html lang="it">
 <head>
+    <?php
+    $external_head_html = function_exists('dci_get_external_head_html') ? dci_get_external_head_html() : '';
+    if (!empty($external_head_html)) {
+        echo $external_head_html;
+    } else {
+    ?>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<?php wp_head(); ?>
+		<?php wp_head(); ?>
+    <?php } ?>
 </head>
 <body <?php body_class(); ?>>
 
 <?php get_template_part("template-parts/common/svg"); ?>
 <?php get_template_part("template-parts/common/sprites"); ?>
 <?php get_template_part("template-parts/common/skiplink"); ?>
+
+<?php $external_header_html = function_exists('dci_get_external_header_html') ? dci_get_external_header_html() : ''; ?>
+
+<?php if (!empty($external_header_html)) : ?>
+    <?php echo $external_header_html; ?>
+    <?php
+    $external_home_redirect = trim((string) dci_get_option('url_homesoloesterno'));
+    if ($external_home_redirect !== '' && !preg_match('#^https?://#i', $external_home_redirect)) {
+        $external_home_redirect = 'https://' . ltrim($external_home_redirect, '/');
+    }
+    if ($external_home_redirect !== '' && filter_var($external_home_redirect, FILTER_VALIDATE_URL)) :
+    ?>
+        <script>
+        document.addEventListener('submit', function(event) {
+          var form = event.target;
+          if (!form || !form.querySelector) return;
+          var searchInput = form.querySelector('input[name="s"]');
+          if (!searchInput) return;
+          event.preventDefault();
+          var query = (searchInput.value || '').trim();
+          var destination = '<?php echo esc_js(trailingslashit($external_home_redirect)); ?>';
+          if (query) {
+            destination += '?s=' + encodeURIComponent(query);
+          }
+          window.location.href = destination;
+        }, true);
+        </script>
+    <?php endif; ?>
+<?php else : ?>
 
 <header
     class="it-header-wrapper"
@@ -258,6 +294,7 @@ $current_group = dci_get_current_group();
     </div>
   </div>
 </header>
+<?php endif; ?>
 
 <?php get_template_part("template-parts/common/search-modal"); ?>
 <?php

--- a/inc/actions.php
+++ b/inc/actions.php
@@ -161,6 +161,43 @@ function custom_menu_order($menu_ord) {
 add_filter('custom_menu_order', 'custom_menu_order');
 add_filter('menu_order', 'custom_menu_order');
 
+/**
+ * In modalità portale esterno inoltra sempre la ricerca verso il portale principale.
+ */
+function dci_redirect_external_search_to_main_portal() {
+    if (is_admin()) {
+        return;
+    }
+
+    $search_term = get_query_var('s');
+    if (!is_string($search_term) || trim($search_term) === '') {
+        return;
+    }
+
+    $external_only_raw = dci_get_option('ck_portalesoloperusoesterno');
+    $is_external_only = in_array(strtolower((string) $external_only_raw), array('1', 'true', 'yes', 'on'), true);
+    if (!$is_external_only) {
+        return;
+    }
+
+    $external_home = trim((string) dci_get_option('url_homesoloesterno'));
+    if ($external_home !== '' && !preg_match('#^https?://#i', $external_home)) {
+        $external_home = 'https://' . ltrim($external_home, '/');
+    }
+    if ($external_home === '' || !filter_var($external_home, FILTER_VALIDATE_URL)) {
+        return;
+    }
+
+    $target_url = add_query_arg('s', $search_term, trailingslashit($external_home));
+    if (!empty($_GET['type'])) {
+        $target_url = add_query_arg('type', sanitize_text_field(wp_unslash($_GET['type'])), $target_url);
+    }
+
+    wp_safe_redirect($target_url, 302);
+    exit;
+}
+add_action('template_redirect', 'dci_redirect_external_search_to_main_portal', 1);
+
 
 /**
  * filter for search
@@ -323,6 +360,17 @@ function dci_admin_bar_customize_header() {
         );
     }
 
+    if (current_user_can('edit_posts') && post_type_exists('richiesta_assistenza')) {
+        $wp_admin_bar->add_menu(
+            array(
+                'parent' => 'design-comuni',
+                'id'     => 'dci-segnalazioni-disservizio',
+                'title'  => __('Segnalazioni disservizio', 'design_comuni_italia'),
+                'href'   => admin_url('edit.php?post_type=richiesta_assistenza'),
+            )
+        );
+    }
+
 }
 add_action( 'admin_bar_menu', 'dci_admin_bar_customize_header', -10 );
 
@@ -412,5 +460,3 @@ function dci_edit_permission_check() {
 
 }
 add_filter( 'admin_head', 'dci_edit_permission_check', 1, 4 );
-
-

--- a/inc/admin/dci_richiesta_assistenza.php
+++ b/inc/admin/dci_richiesta_assistenza.php
@@ -29,7 +29,9 @@ function dci_register_post_type_richiesta_assistenza() {
         'menu_position'      => 5,
         'menu_icon'          => 'dashicons-media-spreadsheet',
         'has_archive'        => false,
-        'capability_type'    => array('richiesta_assistenza', 'richieste_assistenza'),
+        // Usiamo capability standard "post" per rendere il menu visibile agli utenti admin/editor
+        // senza dover assegnare capability personalizzate aggiuntive.
+        'capability_type'    => 'post',
         'capabilities'       => array(
             'create_posts' => 'do_not_allow'
         ),
@@ -209,4 +211,3 @@ add_action( 'do_meta_boxes', 'dci_richiesta_assistenza_remove_publish_mbox', 10,
 function dci_richiesta_assistenza_remove_publish_mbox($post_type, $position, $post){
     remove_meta_box('submitdiv','richiesta_assistenza','side');
 }
-

--- a/inc/admin/options/opzioni_comune.php
+++ b/inc/admin/options/opzioni_comune.php
@@ -151,6 +151,12 @@ function dci_register_comune_options(){
         'desc' => __( 'Utilizzare questo campo per specificare il link alla pagina prenota appuntamento'),
         'type' => 'text'
     ));
+    $header_options->add_field( array(
+        'id'    => $prefix . 'email_prenota_appuntamento',
+        'name' => __('E-mail notifiche prenota appuntamento', 'design_comuni_italia' ),
+        'desc' => __( 'Indirizzo e-mail che riceve le notifiche delle nuove richieste di prenotazione appuntamento (se vuoto, viene usata la e-mail principale).'),
+        'type' => 'text_email'
+    ));
 
 
     
@@ -248,6 +254,32 @@ function dci_register_comune_options(){
             'desc'  => __( 'Inserisci url del portale del comune in modo da indirizzare allo loro homepage.', 'design_comuni_italia' ),
             'type'  => 'text_url',
             'show_on_cb' => 'dci_show_only_super_admin_field', // Usa la funzione per mostrare il campo solo al super admin
+        ));
+
+        $header_options->add_field( array(
+            'id'      => $prefix . 'ck_richiama_footer_portale_principale',
+            'name'    => __('Richiama footer da Url Home', 'design_comuni_italia'),
+            'desc'    => __('Abilita/disabilita il recupero del footer dal portale principale indicato nel campo Url Home Page Personalizzato.', 'design_comuni_italia'),
+            'type'    => 'radio_inline',
+            'default' => 'false',
+            'options' => array(
+                'true'  => __('Sì', 'design_comuni_italia'),
+                'false' => __('No', 'design_comuni_italia'),
+            ),
+            'show_on_cb' => 'dci_show_only_super_admin_field',
+        ));
+
+        $header_options->add_field( array(
+            'id'      => $prefix . 'ck_richiama_head_portale_principale',
+            'name'    => __('Richiama head da Url Home', 'design_comuni_italia'),
+            'desc'    => __('Abilita/disabilita il recupero del blocco head dal portale principale indicato nel campo Url Home Page Personalizzato.', 'design_comuni_italia'),
+            'type'    => 'radio_inline',
+            'default' => 'false',
+            'options' => array(
+                'true'  => __('Sì', 'design_comuni_italia'),
+                'false' => __('No', 'design_comuni_italia'),
+            ),
+            'show_on_cb' => 'dci_show_only_super_admin_field',
         ));
 
     $header_options->add_field( array(

--- a/inc/backend-template.php
+++ b/inc/backend-template.php
@@ -5,11 +5,7 @@
 // includo i singoli file di template di backend
 foreach (glob(get_template_directory() ."/inc/admin/*.php") as $filename)
 {
-    if (
-    	!str_contains($filename, 'richiesta_assistenza')
-    ) {
 	require $filename;
-	}
 }
 
 //includo comuni_config.php

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -84,6 +84,542 @@ function dci_register_servizi_ufficio_route() {
 add_action('rest_api_init', 'dci_register_servizi_ufficio_route');
 
 /**
+ * Espone gli slot prenotabili costruiti dall'orario associato all'Unità organizzativa.
+ */
+function dci_register_appuntamenti_ufficio_route() {
+    register_rest_route('wp/v2', '/appuntamenti/ufficio/', array(
+        'methods' => 'GET',
+        'callback' => 'dci_get_appuntamenti_ufficio'
+    ));
+}
+add_action('rest_api_init', 'dci_register_appuntamenti_ufficio_route');
+
+/**
+ * Espone l'HTML del footer per integrazioni esterne.
+ */
+function dci_register_footer_export_route() {
+    register_rest_route('wp/v2', '/footer/rendered/', array(
+        'methods' => 'GET',
+        'callback' => 'dci_get_rendered_footer',
+        'permission_callback' => '__return_true',
+    ));
+}
+add_action('rest_api_init', 'dci_register_footer_export_route');
+
+/**
+ * Restituisce uno snapshot HTML del footer del tema.
+ *
+ * @return array|null
+ */
+function dci_get_external_footer_payload() {
+    $external_only_raw = dci_get_option('ck_portalesoloperusoesterno');
+    $is_external_only = in_array(strtolower((string) $external_only_raw), array('1', 'true', 'yes', 'on'), true);
+    $external_footer_toggle_raw = dci_get_option('ck_richiama_footer_portale_principale', 'dci_options', 'true');
+    $should_fetch_external_footer = in_array(strtolower((string) $external_footer_toggle_raw), array('1', 'true', 'yes', 'on'), true);
+    $external_home = trim((string) dci_get_option('url_homesoloesterno'));
+
+    if ($is_external_only && !empty($external_home)) {
+        if (!preg_match('#^https?://#i', $external_home)) {
+            $external_home = 'https://' . ltrim($external_home, '/');
+        }
+    }
+
+    if ($is_external_only && $should_fetch_external_footer && !empty($external_home) && filter_var($external_home, FILTER_VALIDATE_URL)) {
+        $current_home = trailingslashit(home_url('/'));
+        $external_parts = wp_parse_url($external_home);
+        $request_args = array(
+            'timeout' => 12,
+            'redirection' => 5,
+            'user-agent' => 'PSR-Theme-Footer-Fetch/1.0 (+'. home_url('/') .')',
+            'sslverify' => false,
+        );
+        $attempted_sources = array();
+
+        $candidate_homes = array();
+        $candidate_homes[] = trailingslashit($external_home);
+        if (!empty($external_parts['scheme']) && !empty($external_parts['host'])) {
+            $root_home = $external_parts['scheme'] . '://' . $external_parts['host'] . '/';
+            $candidate_homes[] = $root_home;
+
+            if (!empty($external_parts['path'])) {
+                $path = '/' . ltrim($external_parts['path'], '/');
+                $candidate_homes[] = trailingslashit($external_parts['scheme'] . '://' . $external_parts['host'] . untrailingslashit($path));
+
+                if (strpos($path, '/index.php/') !== false) {
+                    $before_index = strstr($path, '/index.php/', true);
+                    if ($before_index !== false && $before_index !== '') {
+                        $candidate_homes[] = trailingslashit($external_parts['scheme'] . '://' . $external_parts['host'] . $before_index);
+                    }
+                }
+
+                $dirname_path = untrailingslashit(wp_normalize_path(dirname($path)));
+                if ($dirname_path !== '' && $dirname_path !== '.' && $dirname_path !== '/') {
+                    $candidate_homes[] = trailingslashit($external_parts['scheme'] . '://' . $external_parts['host'] . $dirname_path);
+                }
+            }
+        }
+        $candidate_homes = array_values(array_unique(array_filter($candidate_homes)));
+
+        // Evita loop su stesso host.
+        $current_host = parse_url($current_home, PHP_URL_HOST);
+        foreach ($candidate_homes as $candidate_home) {
+            if (parse_url($candidate_home, PHP_URL_HOST) === $current_host) {
+                continue;
+            }
+
+            $external_api = trailingslashit($candidate_home) . 'wp-json/wp/v2/footer/rendered/';
+            $attempted_sources[] = $external_api;
+            $api_response = wp_remote_get($external_api, $request_args);
+
+            if (!is_wp_error($api_response) && wp_remote_retrieve_response_code($api_response) === 200) {
+                $payload = json_decode(wp_remote_retrieve_body($api_response), true);
+                if (is_array($payload) && !empty($payload['html'])) {
+                    $payload['source'] = $external_api;
+                    $payload['attempted_sources'] = $attempted_sources;
+                    return $payload;
+                }
+            }
+        }
+
+        // Fallback: prova a leggere direttamente homepage esterna ed estrarre il footer.
+        foreach ($candidate_homes as $candidate_home) {
+            if (parse_url($candidate_home, PHP_URL_HOST) === $current_host) {
+                continue;
+            }
+
+            $attempted_sources[] = $candidate_home;
+            $home_response = wp_remote_get($candidate_home, $request_args);
+            if (!is_wp_error($home_response) && wp_remote_retrieve_response_code($home_response) === 200) {
+                $external_html = wp_remote_retrieve_body($home_response);
+                $footer_html = dci_extract_footer_html($external_html);
+                if (!empty($footer_html)) {
+                    return array(
+                        'success' => true,
+                        'generated_at' => current_time('c'),
+                        'html' => $footer_html,
+                        'source' => $candidate_home,
+                        'attempted_sources' => $attempted_sources,
+                        'assets' => array(
+                            'css' => array(),
+                            'js' => array(),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Restituisce uno snapshot HTML del footer del tema.
+ *
+ * @return array
+ */
+function dci_get_rendered_footer() {
+    $external_payload = dci_get_external_footer_payload();
+    if (is_array($external_payload) && !empty($external_payload['html'])) {
+        return $external_payload;
+    }
+
+    ob_start();
+    locate_template('footer.php', true, false);
+    $raw = ob_get_clean();
+
+    $footer_html = dci_extract_footer_html($raw);
+
+    return array(
+        'success' => true,
+        'generated_at' => current_time('c'),
+        'html' => $footer_html,
+        'source' => home_url('/'),
+        'assets' => array(
+            'css' => array(
+                get_template_directory_uri() . '/assets/css/bootstrap-italia-comuni.min.css',
+                get_template_directory_uri() . '/assets/css/comuni.css',
+                get_stylesheet_uri(),
+            ),
+            'js' => array(
+                get_template_directory_uri() . '/assets/js/bootstrap-italia.bundle.min.js',
+                get_template_directory_uri() . '/assets/js/comuni.js',
+            ),
+        ),
+    );
+}
+
+/**
+ * Estrae blocco HTML footer/cookiebar da una pagina completa.
+ *
+ * @param string $html
+ * @return string
+ */
+function dci_extract_footer_html($html) {
+    if (!is_string($html) || $html === '') {
+        return '';
+    }
+
+    if (preg_match('/<section class="cookiebar[\\s\\S]*?<\\/footer>/i', $html, $matches)) {
+        return $matches[0];
+    }
+
+    if (preg_match('/<footer[\\s\\S]*?<\\/footer>/i', $html, $matches)) {
+        return $matches[0];
+    }
+
+    return $html;
+}
+
+/**
+ * Estrae il contenuto interno del tag <head> da una pagina completa.
+ *
+ * @param string $html
+ * @return string
+ */
+function dci_extract_head_html($html) {
+    if (!is_string($html) || $html === '') {
+        return '';
+    }
+
+    if (preg_match('/<head[^>]*>([\\s\\S]*?)<\\/head>/i', $html, $matches)) {
+        return trim($matches[1]);
+    }
+
+    return '';
+}
+
+/**
+ * Estrae il blocco <header> da una pagina completa.
+ *
+ * @param string $html
+ * @return string
+ */
+function dci_extract_header_html($html) {
+    if (!is_string($html) || $html === '') {
+        return '';
+    }
+
+    if (preg_match('/<header[\\s\\S]*?<\\/header>/i', $html, $matches)) {
+        return trim($matches[0]);
+    }
+
+    return '';
+}
+
+/**
+ * Recupera il blocco head del portale principale (se configurato).
+ *
+ * @return string
+ */
+function dci_get_external_head_html() {
+    $external_only_raw = dci_get_option('ck_portalesoloperusoesterno');
+    $is_external_only = in_array(strtolower((string) $external_only_raw), array('1', 'true', 'yes', 'on'), true);
+    $external_head_toggle_raw = dci_get_option('ck_richiama_head_portale_principale', 'dci_options', 'false');
+    $should_fetch_external_head = in_array(strtolower((string) $external_head_toggle_raw), array('1', 'true', 'yes', 'on'), true);
+    $external_home = trim((string) dci_get_option('url_homesoloesterno'));
+
+    if (!$is_external_only || !$should_fetch_external_head) {
+        return '';
+    }
+
+    if (!empty($external_home) && !preg_match('#^https?://#i', $external_home)) {
+        $external_home = 'https://' . ltrim($external_home, '/');
+    }
+
+    if (empty($external_home) || !filter_var($external_home, FILTER_VALIDATE_URL)) {
+        return '';
+    }
+
+    $external_parts = wp_parse_url($external_home);
+    if (empty($external_parts['scheme']) || empty($external_parts['host'])) {
+        return '';
+    }
+
+    $candidate_homes = array();
+    $candidate_homes[] = trailingslashit($external_home);
+    $candidate_homes[] = $external_parts['scheme'] . '://' . $external_parts['host'] . '/';
+    if (!empty($external_parts['path'])) {
+        $path = '/' . ltrim($external_parts['path'], '/');
+        $candidate_homes[] = trailingslashit($external_parts['scheme'] . '://' . $external_parts['host'] . untrailingslashit($path));
+
+        if (strpos($path, '/index.php/') !== false) {
+            $before_index = strstr($path, '/index.php/', true);
+            if ($before_index !== false && $before_index !== '') {
+                $candidate_homes[] = trailingslashit($external_parts['scheme'] . '://' . $external_parts['host'] . $before_index);
+            }
+        }
+
+        $dirname_path = untrailingslashit(wp_normalize_path(dirname($path)));
+        if ($dirname_path !== '' && $dirname_path !== '.' && $dirname_path !== '/') {
+            $candidate_homes[] = trailingslashit($external_parts['scheme'] . '://' . $external_parts['host'] . $dirname_path);
+        }
+    }
+    $candidate_homes = array_values(array_unique(array_filter($candidate_homes)));
+
+    $request_args = array(
+        'timeout' => 12,
+        'redirection' => 5,
+        'user-agent' => 'PSR-Theme-Head-Fetch/1.0 (+'. home_url('/') .')',
+        'sslverify' => false,
+    );
+
+    foreach ($candidate_homes as $candidate_home) {
+        $response = wp_remote_get($candidate_home, $request_args);
+        if (!is_wp_error($response) && wp_remote_retrieve_response_code($response) === 200) {
+            $head_html = dci_extract_head_html(wp_remote_retrieve_body($response));
+            if (!empty($head_html)) {
+                return $head_html;
+            }
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Recupera il blocco header del portale principale (se configurato).
+ *
+ * @return string
+ */
+function dci_get_external_header_html() {
+    $external_only_raw = dci_get_option('ck_portalesoloperusoesterno');
+    $is_external_only = in_array(strtolower((string) $external_only_raw), array('1', 'true', 'yes', 'on'), true);
+    $external_head_toggle_raw = dci_get_option('ck_richiama_head_portale_principale', 'dci_options', 'false');
+    $should_fetch_external_header = in_array(strtolower((string) $external_head_toggle_raw), array('1', 'true', 'yes', 'on'), true);
+    $external_home = trim((string) dci_get_option('url_homesoloesterno'));
+
+    if (!$is_external_only || !$should_fetch_external_header) {
+        return '';
+    }
+
+    if (!empty($external_home) && !preg_match('#^https?://#i', $external_home)) {
+        $external_home = 'https://' . ltrim($external_home, '/');
+    }
+    if (empty($external_home) || !filter_var($external_home, FILTER_VALIDATE_URL)) {
+        return '';
+    }
+
+    $external_parts = wp_parse_url($external_home);
+    if (empty($external_parts['scheme']) || empty($external_parts['host'])) {
+        return '';
+    }
+
+    $candidate_homes = array();
+    $candidate_homes[] = trailingslashit($external_home);
+    $candidate_homes[] = $external_parts['scheme'] . '://' . $external_parts['host'] . '/';
+    $candidate_homes = array_values(array_unique(array_filter($candidate_homes)));
+
+    $request_args = array(
+        'timeout' => 12,
+        'redirection' => 5,
+        'user-agent' => 'PSR-Theme-Header-Fetch/1.0 (+'. home_url('/') .')',
+        'sslverify' => false,
+    );
+
+    foreach ($candidate_homes as $candidate_home) {
+        $response = wp_remote_get($candidate_home, $request_args);
+        if (!is_wp_error($response) && wp_remote_retrieve_response_code($response) === 200) {
+            $header_html = dci_extract_header_html(wp_remote_retrieve_body($response));
+            if (!empty($header_html)) {
+                return $header_html;
+            }
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Genera gli slot appuntamento del mese richiesto a partire dall'orario UO.
+ *
+ * @param WP_REST_Request $request
+ * @return array
+ */
+function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
+    $office_id = absint($request->get_param('id'));
+    $month = absint($request->get_param('month'));
+    $year = absint($request->get_param('year'));
+
+    if ($office_id <= 0) {
+        return array(
+            "error" => array(
+                "code" => 400,
+                "message" => "Parametro id mancante o non valido."
+            )
+        );
+    }
+
+    if ($month < 1 || $month > 12) {
+        $month = (int) wp_date('n');
+    }
+    if ($year < 1) {
+        $year = (int) wp_date('Y');
+    }
+
+    $orario_id = absint(dci_get_meta('orario_uo', '_dci_unita_organizzativa_', $office_id));
+    if ($orario_id <= 0) {
+        return array();
+    }
+
+    $prefix = '_dci_orario_';
+    $data_inizio_raw = get_post_meta($orario_id, $prefix . 'data_inizio', true);
+    $data_fine_raw = get_post_meta($orario_id, $prefix . 'data_fine', true);
+
+    $data_inizio = DateTime::createFromFormat('d-m-Y', $data_inizio_raw) ?: null;
+    $data_fine = DateTime::createFromFormat('d-m-Y', $data_fine_raw) ?: null;
+    if (!$data_inizio || !$data_fine) {
+        return array();
+    }
+
+    $first_day = DateTime::createFromFormat('Y-n-j H:i:s', $year . '-' . $month . '-1 00:00:00');
+    $last_day = clone $first_day;
+    $last_day->modify('last day of this month')->setTime(23, 59, 59);
+
+    $slot_duration = 45; // minuti
+    $giorni_map = array(
+        1 => 'lun',
+        2 => 'mar',
+        3 => 'mer',
+        4 => 'gio',
+        5 => 'ven',
+        6 => 'sab',
+        7 => 'dom',
+    );
+
+    $slots = array();
+    $cursor = clone $first_day;
+    $now = new DateTime('now', wp_timezone());
+
+    while ($cursor <= $last_day) {
+        if ($cursor >= $data_inizio && $cursor <= $data_fine && !dci_is_festivo_nazionale($cursor)) {
+            $weekday = (int) $cursor->format('N');
+            $day_prefix = $giorni_map[$weekday];
+
+            $mattina = get_post_meta($orario_id, $prefix . $day_prefix . '_mattina', true);
+            $pomeriggio = get_post_meta($orario_id, $prefix . $day_prefix . '_pomeriggio', true);
+
+            $fasce = array_filter(array($mattina, $pomeriggio));
+            foreach ($fasce as $fascia) {
+                $parsed = dci_parse_orario_range($fascia);
+                if (!$parsed) {
+                    continue;
+                }
+
+                list($start_h, $start_m, $end_h, $end_m) = $parsed;
+                $slot_start = (clone $cursor)->setTime($start_h, $start_m, 0);
+                $slot_end_limit = (clone $cursor)->setTime($end_h, $end_m, 0);
+
+                while ((clone $slot_start)->modify('+' . $slot_duration . ' minutes') <= $slot_end_limit) {
+                    $slot_end = (clone $slot_start)->modify('+' . $slot_duration . ' minutes');
+                    if ($slot_start <= $now) {
+                        $slot_start = $slot_end;
+                        continue;
+                    }
+
+                    $slots[] = array(
+                        'startDate' => $slot_start->format('Y-m-d\TH:i'),
+                        'endDate' => $slot_end->format('Y-m-d\TH:i'),
+                    );
+                    $slot_start = $slot_end;
+                }
+            }
+        }
+
+        $cursor->modify('+1 day')->setTime(0, 0, 0);
+    }
+
+    return $slots;
+}
+
+/**
+ * Verifica se una data ricade in un giorno festivo nazionale.
+ *
+ * @param DateTime $date
+ * @return bool
+ */
+function dci_is_festivo_nazionale(DateTime $date) {
+    // Tutte le domeniche sono giorni festivi a livello nazionale.
+    if ((int) $date->format('N') === 7) {
+        return true;
+    }
+
+    $fixed_holidays = array(
+        '01-01', // Capodanno
+        '01-06', // Epifania
+        '04-25', // Liberazione
+        '05-01', // Festa del Lavoro
+        '06-02', // Festa della Repubblica
+        '08-15', // Ferragosto
+        '11-01', // Ognissanti
+        '12-08', // Immacolata
+        '12-25', // Natale
+        '12-26', // Santo Stefano
+    );
+    $day_month = $date->format('m-d');
+    if (in_array($day_month, $fixed_holidays, true)) {
+        return true;
+    }
+
+    // Festività regionale applicata solo ai comuni con regione impostata su Sicilia.
+    if (dci_is_regione_sicilia() && $day_month === '05-15') {
+        return true;
+    }
+
+    $year = (int) $date->format('Y');
+    $easter_timestamp = easter_date($year);
+    $easter = (new DateTime('@' . $easter_timestamp))->setTimezone(wp_timezone());
+    $easter_monday = (clone $easter)->modify('+1 day');
+
+    return $date->format('Y-m-d') === $easter->format('Y-m-d') ||
+        $date->format('Y-m-d') === $easter_monday->format('Y-m-d');
+}
+
+/**
+ * Verifica se il comune configurato appartiene alla Regione Sicilia.
+ *
+ * @return bool
+ */
+function dci_is_regione_sicilia() {
+    $nome_regione = dci_get_option('nome_regione');
+    if (!is_string($nome_regione)) {
+        return false;
+    }
+
+    return sanitize_title($nome_regione) === 'sicilia';
+}
+
+/**
+ * Parsing range orario "08:30 - 12:30".
+ *
+ * @param string $range
+ * @return array|null
+ */
+function dci_parse_orario_range($range) {
+    if (!is_string($range) || trim($range) === '') {
+        return null;
+    }
+
+    if (!preg_match('/^\s*(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})\s*$/', $range, $matches)) {
+        return null;
+    }
+
+    $start_h = (int) $matches[1];
+    $start_m = (int) $matches[2];
+    $end_h = (int) $matches[3];
+    $end_m = (int) $matches[4];
+
+    if ($start_h > 23 || $end_h > 23 || $start_m > 59 || $end_m > 59) {
+        return null;
+    }
+
+    if ($end_h < $start_h || ($end_h === $start_h && $end_m <= $start_m)) {
+        return null;
+    }
+
+    return array($start_h, $start_m, $end_h, $end_m);
+}
+
+/**
  * restituisce i servizi che sono disponibili presso l'Unità Organizzativa passata come parametro (id o title)
  * @param WP_REST_Request $request
  * @return array[]
@@ -207,7 +743,8 @@ function dci_save_richiesta_assistenza(){
         $ticket_title = 'ticket_'.$timestamp;
         $postId = wp_insert_post(array(
             'post_type' => 'richiesta_assistenza',
-            'post_title' =>  $ticket_title
+            'post_title' =>  $ticket_title,
+            'post_status' => 'publish'
         ));
     }
 
@@ -246,8 +783,11 @@ function dci_save_richiesta_assistenza(){
         update_post_meta($postId, '_dci_richiesta_assistenza_dettagli',  $params['dettagli']);
     }
 
+    $mail_sent = dci_send_richiesta_assistenza_notification($postId, $params, $ticket_title);
+
     echo json_encode(array(
         "success" => true,
+        "mail_sent" => $mail_sent,
         "richiesta_assistenza" => array(
             "id" => $postId),
         "title" => $ticket_title
@@ -258,11 +798,74 @@ add_action("wp_ajax_save_richiesta_assistenza" , "dci_save_richiesta_assistenza"
 add_action("wp_ajax_nopriv_save_richiesta_assistenza" , "dci_save_richiesta_assistenza");
 
 /**
+ * Invia notifica e-mail per nuove richieste assistenza/disservizio.
+ *
+ * @param int   $postId
+ * @param array $params
+ * @param string $ticket_title
+ * @return bool
+ */
+function dci_send_richiesta_assistenza_notification($postId, $params, $ticket_title) {
+    if (empty($postId)) {
+        return false;
+    }
+
+    $recipients = array();
+    $email_principale = dci_get_option('email_principale');
+    if (is_email($email_principale)) {
+        $recipients[] = $email_principale;
+    }
+
+    $admin_email = get_option('admin_email');
+    if (is_email($admin_email)) {
+        $recipients[] = $admin_email;
+    }
+
+    $recipients = array_values(array_unique(array_filter($recipients)));
+    if (empty($recipients)) {
+        return false;
+    }
+
+    $subject = sprintf('[%s] Nuova segnalazione disservizio', wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES));
+    $message = implode("\n", array(
+        'È stata creata una nuova segnalazione di disservizio.',
+        '',
+        'ID richiesta: ' . $postId,
+        'Ticket: ' . $ticket_title,
+        'Nome: ' . ($params['nome'] ?? ''),
+        'Cognome: ' . ($params['cognome'] ?? ''),
+        'Email: ' . ($params['email'] ?? ''),
+        'Servizio: ' . ($params['servizio'] ?? ''),
+        'Dettagli: ' . ($params['dettagli'] ?? ''),
+        '',
+        'Link nel pannello admin: ' . admin_url('post.php?post=' . $postId . '&action=edit'),
+    ));
+
+    $headers = array('Content-Type: text/plain; charset=UTF-8');
+    if (is_email($email_principale)) {
+        $headers[] = 'From: ' . wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES) . ' <' . $email_principale . '>';
+    }
+    if (is_email($params['email'] ?? '')) {
+        $headers[] = 'Reply-To: ' . $params['email'];
+    }
+
+    $result = true;
+    foreach ($recipients as $to) {
+        $sent = wp_mail($to, $subject, $message, $headers);
+        $result = $result && $sent;
+    }
+
+    return $result;
+}
+
+/**
  * crea contenuto di tipo Appuntamento
  */
 function dci_save_appuntamento(){
 
     $params = json_decode(json_encode($_POST), true);
+    $postId = 0;
+    $appuntamento_title = '';
 
     date_default_timezone_set('Europe/Rome');
     $data = date('Y-m-d\TH:i:s');
@@ -273,7 +876,8 @@ function dci_save_appuntamento(){
 
         $postId = wp_insert_post(array(
             'post_type' => 'appuntamento',
-            'post_title' =>  $appuntamento_title
+            'post_title' =>  $appuntamento_title,
+            'post_status' => 'publish'
         ));
     }
 
@@ -319,9 +923,12 @@ function dci_save_appuntamento(){
         update_post_meta($postId, '_dci_appuntamento_data_ora_fine_appuntamento',  $endDate);
     }
 
+    $mail_sent = dci_send_appuntamento_notification($postId, $params, $data);
+
     echo json_encode(array(
         "success" => true,
         "message" => 'Contenuto creato con successo: '.$postId,
+        "mail_sent" => $mail_sent,
         "appuntamento" => array(
             "id" => $postId),
         "title" => $appuntamento_title
@@ -333,3 +940,80 @@ function dci_save_appuntamento(){
 
 add_action("wp_ajax_save_appuntamento" , "dci_save_appuntamento");
 add_action("wp_ajax_nopriv_save_appuntamento" , "dci_save_appuntamento");
+
+/**
+ * Invia una notifica e-mail alla creazione di una richiesta appuntamento.
+ *
+ * @param int    $postId
+ * @param array  $params
+ * @param string $data
+ * @return bool
+ */
+function dci_send_appuntamento_notification($postId, $params, $data) {
+    if (empty($postId)) {
+        return false;
+    }
+
+    $to = dci_get_option('email_prenota_appuntamento');
+    if (empty($to)) {
+        $to = dci_get_option('email_principale');
+    }
+    if (empty($to)) {
+        $to = get_option('admin_email');
+    }
+    if (!is_email($to)) {
+        return false;
+    }
+
+    $service_name = '';
+    if (array_key_exists('service', $params) && $params['service'] != "null") {
+        $service_obj = json_decode(stripslashes($params['service']), true);
+        $service_name = $service_obj['name'] ?? '';
+    }
+
+    $office_name = '';
+    if (array_key_exists('office', $params) && $params['office'] != "null") {
+        $office_obj = json_decode(stripslashes($params['office']), true);
+        $office_name = $office_obj['name'] ?? '';
+    }
+
+    $appointment_start = '';
+    $appointment_end = '';
+    if (array_key_exists('appointment', $params) && $params['appointment'] != "null") {
+        $appointment_obj = json_decode(stripslashes($params['appointment']), true);
+        $appointment_start = $appointment_obj['startDate'] ?? '';
+        $appointment_end = $appointment_obj['endDate'] ?? '';
+    }
+
+    $subject = sprintf('[%s] Nuova richiesta prenotazione appuntamento', wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES));
+    $message_lines = array(
+        'È stata creata una nuova richiesta di prenotazione appuntamento.',
+        '',
+        'ID richiesta: ' . $postId,
+        'Data richiesta: ' . $data,
+        'Nome: ' . ($params['name'] ?? ''),
+        'Cognome: ' . ($params['surname'] ?? ''),
+        'Email richiedente: ' . ($params['email'] ?? ''),
+        'Ufficio: ' . $office_name,
+        'Servizio: ' . $service_name,
+        'Dettagli: ' . ($params['moreDetails'] ?? ''),
+        'Inizio appuntamento: ' . $appointment_start,
+        'Fine appuntamento: ' . $appointment_end,
+        '',
+        'Link nel pannello admin: ' . admin_url('post.php?post=' . $postId . '&action=edit'),
+    );
+    $message = implode("\n", $message_lines);
+    $headers = array('Content-Type: text/plain; charset=UTF-8');
+
+    $from = dci_get_option('email_principale');
+    if (is_email($from)) {
+        $headers[] = 'From: ' . wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES) . ' <' . $from . '>';
+    }
+
+    $requester_email = $params['email'] ?? '';
+    if (is_email($requester_email)) {
+        $headers[] = 'Reply-To: ' . $requester_email;
+    }
+
+    return wp_mail($to, $subject, $message, $headers);
+}

--- a/page-templates/assistenza.php
+++ b/page-templates/assistenza.php
@@ -23,7 +23,9 @@ get_header();
 		while ( have_posts() ) :
 			the_post();
 
-			$description = dci_get_meta('descrizione','_dci_page_',$post->ID);
+				$description = dci_get_meta('descrizione','_dci_page_',$post->ID);
+            $privacy_url = dci_get_template_page_url('page-templates/privacy.php') ?: home_url('/page-templates/privacy');
+            $area_riservata_url = dci_get_option('area_riservata') ?: wp_login_url();
             $categorie_servizio = get_terms(array (
                 'taxonomy' => 'categorie_servizio',
                 'orderby' => 'name',
@@ -51,7 +53,7 @@ get_header();
                     </div>
                     <p class="subtitle-small pb-40 mb-0">
                         Hai un’identità digitale SPID o CIE?
-                        <a href="#">Accedi</a>
+                        <a href="<?php echo esc_url($area_riservata_url); ?>">Accedi</a>
                     </p>
                 </div>
             </div>
@@ -215,7 +217,7 @@ get_header();
                             <div class="privacy-wrapper">
                                 <p class="text-paragraph mb-3">
                                     Per i dettagli sul trattamento dei dati personali consulta l’
-                                    <a href="#" class="t-primary">informativa sulla privacy.</a>
+                                    <a href="<?php echo esc_url($privacy_url); ?>" class="t-primary">informativa sulla privacy.</a>
                                 </p>
 
                                 <div class="form-check mb-2">

--- a/template-parts/home/argomenti.php
+++ b/template-parts/home/argomenti.php
@@ -14,6 +14,7 @@ $check_immagini = dci_get_option('ch_show_sfondo_argomenti','homepage');
 
 $img_default = get_template_directory_uri() . '/assets/img/bg_placeholder-blu.png';
 $img_ricavata = dci_get_option('immagine-argomenti','homepage');
+$has_custom_bg = (isset($img_ricavata) && !empty($img_ricavata) && $img_ricavata !== null);
 $img = (isset($img_ricavata) && !empty($img_ricavata) && $img_ricavata !== null)
     ? $img_ricavata
     : $img_default;
@@ -107,28 +108,33 @@ $img = (isset($img_ricavata) && !empty($img_ricavata) && $img_ricavata !== null)
 <br><br>
 
 <style>
-/* Sfondo sezione Argomenti in Evidenza */
+/* Sfondo sezione Argomenti in Evidenza (dinamico sul colore tema primaria) */
 .argomenti-evidenza-bg {
-    background-image: url('<?= $img ?>');
+    background-color: var(--bs-primary, #026e64);
+    <?php if ($has_custom_bg) { ?>
+    background-image: url('<?php echo esc_url($img); ?>');
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
+    <?php } ?>
     position: relative;
     padding: 60px 0;
-    overflow: hidden; /* Assicura che il pseudo-elemento non esca dai bordi */
+    overflow: hidden;
+    isolation: isolate;
 }
 
-/* Overlay sfocato e opaco */
+/* Layer geometrico simile al precedente sfondo immagine */
 .argomenti-evidenza-bg::before {
     content: "";
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.2); /* Opacità nera: 0.4 puoi regolare */
-    /* backdrop-filter: blur(0.1rem);  */
+    inset: 0;
     z-index: 1;
+    background:
+        <?php if (!$has_custom_bg) { ?>
+        linear-gradient(160deg, rgba(255, 255, 255, 0.08) 8%, transparent 8%) 0 0 / 42% 100% no-repeat,
+        linear-gradient(20deg, rgba(255, 255, 255, 0.09) 10%, transparent 10%) 100% 0 / 48% 100% no-repeat,
+        <?php } ?>
+        linear-gradient(120deg, rgba(0, 0, 0, 0.22), rgba(0, 0, 0, 0.1));
 }
 
 /* Contenuto sopra l'overlay */

--- a/template-parts/prenotazione/content.php
+++ b/template-parts/prenotazione/content.php
@@ -1,7 +1,19 @@
 <?php
     $uffici = get_posts(array(
         'posts_per_page' => -1,
-        'post_type' => 'unita_organizzativa'
+        'post_type' => 'unita_organizzativa',
+        'meta_query' => array(
+            'relation' => 'AND',
+            array(
+                'key' => '_dci_unita_organizzativa_orario_uo',
+                'compare' => 'EXISTS',
+            ),
+            array(
+                'key' => '_dci_unita_organizzativa_orario_uo',
+                'value' => '',
+                'compare' => '!=',
+            ),
+        ),
     ));
 
     $months = array();
@@ -12,7 +24,21 @@
         if($currentMonth >= 12) $currentMonth = 0;
         $currentMonth++;
     }
+    $privacy_url = dci_get_template_page_url('page-templates/privacy.php') ?: home_url('/page-templates/privacy');
+    $area_riservata_url = dci_get_option('area_riservata') ?: wp_login_url();
 ?>
+
+<style>
+    #radio-appointment {
+        max-height: 420px;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    #radio-appointment .radio-body label {
+        overflow-wrap: anywhere;
+    }
+</style>
 
 <div class="it-page-sections-container">
 
@@ -160,10 +186,14 @@
 
     <!-- Step 4 -->
     <section class="d-none page-step it-page-section" data-steps="4">
+        <p class="text-paragraph mb-3">
+            Per i dettagli sul trattamento dei dati personali consulta l’
+            <a href="<?php echo esc_url($privacy_url); ?>" class="t-primary">informativa sulla privacy.</a>
+        </p>
         <p class="subtitle-small pb-40 mb-0 d-lg-none">
             Hai un’identità digitale SPID o CIE?
             <a class="title-small-semi-bold t-primary underline"
-                href="./iscrizione-graduatoria-accedere-servizio.html"
+                href="<?php echo esc_url($area_riservata_url); ?>"
             >
                 Accedi
             </a>

--- a/template-parts/segnalazione/content.php
+++ b/template-parts/segnalazione/content.php
@@ -2,6 +2,8 @@
 <?php
 
     $disservizi = dci_get_disservizi_names();
+    $privacy_url = dci_get_template_page_url('page-templates/privacy.php') ?: home_url('/page-templates/privacy');
+    $area_riservata_url = dci_get_option('area_riservata') ?: wp_login_url();
 
     $uffici = get_posts(array(
         'posts_per_page' => -1,
@@ -35,7 +37,7 @@
             </p>
             <p class="text-paragraph mb-0">
               Per i dettagli sul trattamento dei dati personali consulta l’
-              <a href="#" class="t-primary">informativa sulla privacy.</a>
+              <a href="<?php echo esc_url($privacy_url); ?>" class="t-primary">informativa sulla privacy.</a>
             </p>
     
             <div class="form-check mt-4 mb-3 mt-md-40 mb-lg-40">
@@ -62,10 +64,10 @@
                 </div>
                 <div class="card-body p-0">
                     <div class="select-wrapper p-0 mt-1 select-partials">
-                        <label for="appointment" class="visually-hidden">
+                        <label for="luogo-disservizio" class="visually-hidden">
                             Indica il luogo del disservizio
                         </label>
-                        <select id="appointment" class="">
+                        <select id="luogo-disservizio" class="">
                             <option selected="selected" value="">
                                 Indica il luogo del disservizio
                             </option>
@@ -105,7 +107,7 @@
                         <label for="motivo-appuntamento" class="visually-hidden">
                             Tipologia di Disservizio
                         </label>
-                        <select id="appointment" class="">
+                        <select id="motivo-appuntamento" class="">
                             <option selected="selected" value="">
                                 Tipologia di Disservizio
                             </option>
@@ -135,95 +137,14 @@
             </div>
         </div>
         <div class="cmp-card">
-      <div class="card has-bkg-grey shadow-sm">
-        <div class="card-header border-0 p-0 mb-lg-30 m-0">
-          <div class="d-flex">
-                <h2 class="title-xxlarge mb-1">Autore della segnalazione</h2>
-          </div>
-          <p class="subtitle-small mb-0">Informazione su di te</p>
-    
-    
-    
-    
+            <div class="card has-bkg-grey shadow-sm p-big">
+                <div class="card-body p-0">
+                    <p class="subtitle-small mb-0">
+                        I dati del richiedente verranno inseriti nel passaggio successivo.
+                    </p>
+                </div>
+            </div>
         </div>
-        <div class="card-body p-0">
-          
-                        <div class="cmp-info-button-card mt-3">
-                          <div class="card p-3 p-lg-4">
-                            <div class="card-body p-0">
-                              <h3 class="big-title mb-0">Mario Rossi</h3>
-                        
-                        
-                        
-                        
-                              <p class="card-info">Codice Fiscale <br> <span>GLABNC72H25H501Y</span></p>
-                        
-                        
-                              <div class="accordion-item">
-                                <div class="accordion-header" id="heading-collapse-parents">
-                                  <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-parents" aria-expanded="true" aria-controls="collapse-parents" data-focus-mouse="false">
-                                    <span class="d-flex align-items-center">
-                                    Mostra tutto
-                                      <svg class="icon icon-primary icon-sm">
-                                        <use href="../assets/bootstrap-italia/dist/svg/sprites.svg#it-expand"></use>
-                                      </svg>
-                                    </span>
-                                  </button>
-                              
-                              
-                                </div>
-                                <div id="collapse-parents" class="accordion-collapse collapse show" role="region" style="">
-                                  <div class="accordion-body p-0">
-                                    <div class="cmp-info-summary bg-white has-border">
-                                      <div class="card">
-                                    
-                                        <div class="card-header border-bottom border-light p-0 mb-0 d-flex justify-content-between d-flex justify-content-end">
-                                          <h4 class="title-large-semi-bold mb-3">Contatti</h4>
-                                          <a href="#" class="d-none text-decoration-none"><span class="text-button-sm-semi t-primary">Modifica</span></a>
-                                        </div>
-                                    
-                                        <div class="card-body p-0">
-                                          <div class="single-line-info border-light">
-                                            <div class="text-paragraph-small">Telefono</div>
-                                            <div class="border-light">
-                                              <p class="data-text">
-                                                +39 331 1234567
-                                              </p>
-                                    
-                                    
-                                    
-                                            </div>
-                                          </div>
-                                          <div class="single-line-info border-light">
-                                            <div class="text-paragraph-small">Email</div>
-                                            <div class="border-light">
-                                              <p class="data-text">
-                                                mario.rossi@gmail.com
-                                              </p>
-                                    
-                                    
-                                    
-                                            </div>
-                                          </div>
-                                        </div>
-                                        <div class="card-footer p-0 d-none">
-                                        </div>
-                                      </div>
-                                    </div>    </div>
-                                </div>
-                              </div>
-                        
-                        
-                        
-                        
-                        
-                        
-                        
-                            </div>
-                          </div>
-                        </div>    </div>
-      </div>
-    </div>
     </section>
 
     <!-- Step 3 -->
@@ -287,7 +208,7 @@
         <p class="subtitle-small pb-40 mb-0 d-lg-none">
             Hai un’identità digitale SPID o CIE?
             <a class="title-small-semi-bold t-primary underline"
-                href="./iscrizione-graduatoria-accedere-servizio.html"
+                href="<?php echo esc_url($area_riservata_url); ?>"
             >
                 Accedi
             </a>


### PR DESCRIPTION
### Motivation

- Add support for a dedicated "external-only" portal mode that can pull header/footer from a configured main portal and redirect searches to that portal. 
- Expose appointment slots and footer HTML via the REST API to allow front-end widgets to fetch data from the theme. 
- Improve assistenza/segnalazione and prenotazione flows with better client-side validation, clearer UI messages and server-side notifications. 

### Description

- Introduced new admin options (in `opzioni_comune.php`) such as `url_homesoloesterno`, `ck_portalesoloperusoesterno`, toggles to fetch external `head`/`footer`, and `email_prenota_appuntamento`, and added an admin bar link for `richiesta_assistenza` when appropriate. 
- Implemented external portal integration and helpers in `funzionalita_trasversali.php`: added REST routes `wp/v2/appuntamenti/ufficio/` and `wp/v2/footer/rendered/`, functions to fetch/extract external `head`, `header` and `footer`, and `dci_get_appuntamenti_ufficio()` that generates 45-minute slots from UO schedules while honoring holidays. 
- Added server-side email notifications: `dci_send_richiesta_assistenza_notification()` and `dci_send_appuntamento_notification()` and ensured created `richiesta_assistenza` and `appuntamento` posts are published by default; adjusted CPT `capability_type` for `richiesta_assistenza` to `post`. 
- Implemented redirect logic to forward site searches to the configured external home in `dci_redirect_external_search_to_main_portal()` and made template-level fallbacks for rendering external header/footer in `header.php` and `footer.php`. 
- Rewrote and hardened front-end JS and templates: updated `assets-src/js/booking.js` and bundled `assets/js/booking.js` to use the new REST endpoints and to handle empty responses with user-friendly messages; replaced large portions of `segnalazione.js` with a modular IIFE implementing step navigation, validation and AJAX submission to `save_richiesta_assistenza`; adjusted templates (`assistenza.php`, `prenotazione` and `segnalazione` content parts) to use privacy and area URLs from theme options and improved CSS/markup (e.g. `argomenti.php` background handling). 
- Minor backend change: `backend-template.php` now includes all `inc/admin/*.php` files (removed previous exclusion), and various small UI/CSS tweaks were applied across templates. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c253f15ac483329179896ef4f37fd3)