### PR TITLE
Cache external header/footer/head, reduce HTTP timeouts, and optimize heavy queries/loops

### DIFF
--- a/docs/cpu-audit-ultimi-15-giorni.md
+++ b/docs/cpu-audit-ultimi-15-giorni.md
@@ -1,0 +1,73 @@
+# Audit CPU - file modificati negli ultimi 15 giorni
+
+Data analisi: 2026-04-15
+Repository: `psr-theme-wordpress`
+Finestra temporale analizzata: ultimi 15 giorni di commit Git.
+
+## Metodo
+- Elenco file toccati con `git log --since='15 days ago' --name-only`.
+- Ispezione pattern ad alto costo (`WP_Query`, `get_posts`, `posts_per_page => -1`, loop annidati).
+- Revisione mirata dei file più sensibili lato frontend (home/tassonomie) e utility globali.
+
+## Principali candidati al consumo CPU
+
+### 1) Homepage: query notizie in evidenza senza limite
+File: `template-parts/home/notizie-auto-evidenza.php`
+
+Punto critico:
+- La query carica **tutte** le notizie evidenziate (`posts_per_page => -1`) e poi filtra in PHP.
+- In presenza di molte notizie, il costo è alto su ogni request della home.
+
+Dettagli:
+- Query con `posts_per_page => -1`: riga 86.
+- Subito dopo viene fatto filtro applicativo in ciclo `foreach` sui post trovati: righe 110-157.
+
+Impatto:
+- Crescita CPU e memoria proporzionale al numero totale di notizie evidenziate.
+- Picchi più visibili in assenza di object/page cache.
+
+### 2) Utility globali: doppio loop su dataset potenzialmente grandi
+File: `inc/utils.php`
+
+Punto critico:
+- In `dci_get_related_bandi()` vengono caricati bandi e servizi, poi confrontati con loop annidati.
+- La complessità è circa `O(bandi * servizi)` più accessi meta nel loop interno.
+
+Dettagli:
+- Caricamento bandi: riga 1032.
+- Caricamento servizi ids senza limite (`numberposts => -1`): righe 1035-1039 e 1059.
+- Loop annidato bandi × servizi: righe 1062-1066.
+
+Impatto:
+- Rallentamenti evidenti se il numero di elementi cresce.
+- Potenziale saturazione CPU su endpoint/pagine che chiamano questa utility frequentemente.
+
+### 3) Hook `init`: job one-shot che può essere pesante al primo giro
+File: `functions.php`
+
+Punto critico:
+- Funzione su hook `init` che, se l'opzione non è impostata, carica tutte le notizie (`posts_per_page => -1`) e aggiorna meta per ciascun post.
+
+Dettagli:
+- Query completa notizie: righe 306-311.
+- Loop con `update_post_meta` per ogni post: righe 312-322.
+- Esecuzione agganciata a `init`: riga 329.
+
+Impatto:
+- Di norma è un costo "una tantum".
+- Se l'opzione viene persa/non salvata (cache/object-cache anomalo, DB issue), il costo si ripete e può creare picchi importanti.
+
+## Cosa NON sembra il principale colpevole
+- `inc/lib/parsedown.php`: contiene molti loop interni, ma è una libreria parser; il costo dipende dall'uso applicativo e non mostra pattern di loop infinito o codice malevolo evidente.
+- `inc/activationTrasparenza.php`: `set_time_limit(400)` aumenta timeout ma non crea da solo CPU alta; è più un segnale di operazioni lunghe durante attivazione.
+
+## Priorità intervento consigliata
+1. **Alta**: limitare la query home in `notizie-auto-evidenza.php` (evitare `-1` e spostare più filtri in query SQL/meta_query quando possibile).
+2. **Alta**: riscrivere `dci_get_related_bandi()` per evitare loop annidati e accessi meta ripetuti.
+3. **Media**: proteggere meglio la funzione one-shot su `init` (lock transiente + batch) per evitare riesecuzioni costose.
+
+## Suggerimenti rapidi (safe)
+- Impostare limiti espliciti (`posts_per_page`) anche quando poi si filtrano risultati.
+- Usare `'fields' => 'ids'` quando non serve l'oggetto post completo.
+- Precaricare meta (`update_meta_cache`) o ristrutturare i dati per evitare `get_post_meta` in loop annidati.
+- Aggiungere caching (transient/object cache) ai risultati derivati più costosi.

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -125,11 +125,17 @@ function dci_get_external_footer_payload() {
     }
 
     if ($is_external_only && $should_fetch_external_footer && !empty($external_home) && filter_var($external_home, FILTER_VALIDATE_URL)) {
+        $cache_key = 'dci_ext_footer_' . md5(strtolower((string) $external_home) . '|' . home_url('/'));
+        $cached_payload = get_transient($cache_key);
+        if (is_array($cached_payload)) {
+            return !empty($cached_payload['html']) ? $cached_payload : null;
+        }
+
         $current_home = trailingslashit(home_url('/'));
         $external_parts = wp_parse_url($external_home);
         $request_args = array(
-            'timeout' => 12,
-            'redirection' => 5,
+            'timeout' => 4,
+            'redirection' => 3,
             'user-agent' => 'PSR-Theme-Footer-Fetch/1.0 (+'. home_url('/') .')',
             'sslverify' => false,
         );
@@ -176,6 +182,7 @@ function dci_get_external_footer_payload() {
                 if (is_array($payload) && !empty($payload['html'])) {
                     $payload['source'] = $external_api;
                     $payload['attempted_sources'] = $attempted_sources;
+                    set_transient($cache_key, $payload, 10 * MINUTE_IN_SECONDS);
                     return $payload;
                 }
             }
@@ -193,7 +200,7 @@ function dci_get_external_footer_payload() {
                 $external_html = wp_remote_retrieve_body($home_response);
                 $footer_html = dci_extract_footer_html($external_html);
                 if (!empty($footer_html)) {
-                    return array(
+                    $payload = array(
                         'success' => true,
                         'generated_at' => current_time('c'),
                         'html' => $footer_html,
@@ -204,9 +211,14 @@ function dci_get_external_footer_payload() {
                             'js' => array(),
                         ),
                     );
+                    set_transient($cache_key, $payload, 10 * MINUTE_IN_SECONDS);
+                    return $payload;
                 }
             }
         }
+
+        // Negative cache per evitare timeout ripetuti ad ogni request.
+        set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
     }
 
     return null;
@@ -359,9 +371,15 @@ function dci_get_external_head_html() {
     }
     $candidate_homes = array_values(array_unique(array_filter($candidate_homes)));
 
+    $cache_key = 'dci_ext_head_' . md5(strtolower((string) $external_home) . '|' . home_url('/'));
+    $cached_head = get_transient($cache_key);
+    if (is_array($cached_head)) {
+        return !empty($cached_head['html']) ? $cached_head['html'] : '';
+    }
+
     $request_args = array(
-        'timeout' => 12,
-        'redirection' => 5,
+        'timeout' => 4,
+        'redirection' => 3,
         'user-agent' => 'PSR-Theme-Head-Fetch/1.0 (+'. home_url('/') .')',
         'sslverify' => false,
     );
@@ -371,11 +389,13 @@ function dci_get_external_head_html() {
         if (!is_wp_error($response) && wp_remote_retrieve_response_code($response) === 200) {
             $head_html = dci_extract_head_html(wp_remote_retrieve_body($response));
             if (!empty($head_html)) {
+                set_transient($cache_key, array('html' => $head_html), 10 * MINUTE_IN_SECONDS);
                 return $head_html;
             }
         }
     }
 
+    set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
     return '';
 }
 
@@ -412,9 +432,15 @@ function dci_get_external_header_html() {
     $candidate_homes[] = $external_parts['scheme'] . '://' . $external_parts['host'] . '/';
     $candidate_homes = array_values(array_unique(array_filter($candidate_homes)));
 
+    $cache_key = 'dci_ext_header_' . md5(strtolower((string) $external_home) . '|' . home_url('/'));
+    $cached_header = get_transient($cache_key);
+    if (is_array($cached_header)) {
+        return !empty($cached_header['html']) ? $cached_header['html'] : '';
+    }
+
     $request_args = array(
-        'timeout' => 12,
-        'redirection' => 5,
+        'timeout' => 4,
+        'redirection' => 3,
         'user-agent' => 'PSR-Theme-Header-Fetch/1.0 (+'. home_url('/') .')',
         'sslverify' => false,
     );
@@ -424,11 +450,13 @@ function dci_get_external_header_html() {
         if (!is_wp_error($response) && wp_remote_retrieve_response_code($response) === 200) {
             $header_html = dci_extract_header_html(wp_remote_retrieve_body($response));
             if (!empty($header_html)) {
+                set_transient($cache_key, array('html' => $header_html), 10 * MINUTE_IN_SECONDS);
                 return $header_html;
             }
         }
     }
 
+    set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
     return '';
 }
 

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1059,19 +1059,33 @@ if(!function_exists("dci_get_related_bando")) {
         $servizi =   get_posts( $args );
 
         $result = array();
-        foreach ($bandi as $bando) {
-            foreach ($servizi as $servizio) {
-                $array_servizi =  dci_get_meta('servizi', '_dci_documento_pubblico_', $bando-> ID) ;
-                if (is_array( $array_servizi ) && in_array($servizio,$array_servizi)) {
+        $servizi_lookup = array_fill_keys(array_map('intval', $servizi), true);
 
-                    $result [] = array(
-                        'id' => $bando -> ID,
-                        'titolo' => $bando-> post_title,
-                        'link' => get_permalink($bando -> ID),
-                        'description' =>  dci_get_meta('descrizione_breve', '_dci_documento_pubblico_', $bando-> ID)
-                    );
+        foreach ($bandi as $bando) {
+            $array_servizi = dci_get_meta('servizi', '_dci_documento_pubblico_', $bando->ID);
+
+            if (!is_array($array_servizi) || empty($array_servizi)) {
+                continue;
+            }
+
+            $has_related_servizio = false;
+            foreach ($array_servizi as $servizio_id) {
+                if (isset($servizi_lookup[(int) $servizio_id])) {
+                    $has_related_servizio = true;
+                    break;
                 }
             }
+
+            if (!$has_related_servizio) {
+                continue;
+            }
+
+            $result[] = array(
+                'id' => $bando->ID,
+                'titolo' => $bando->post_title,
+                'link' => get_permalink($bando->ID),
+                'description' => dci_get_meta('descrizione_breve', '_dci_documento_pubblico_', $bando->ID)
+            );
         }
 
        return $result;

--- a/template-parts/home/notizie-auto-evidenza.php
+++ b/template-parts/home/notizie-auto-evidenza.php
@@ -83,7 +83,7 @@ $args = array(
     ),
     'orderby'             => 'date',
     'order'               => 'DESC',
-    'posts_per_page'      => -1,
+    'posts_per_page'      => $posts_per_page,
     'no_found_rows'       => true,
     'ignore_sticky_posts' => true,
 );


### PR DESCRIPTION
### Motivation
- Reduce CPU and latency caused by repeated external HTTP fetches for header/head/footer and heavy in-PHP filtering of large WP_Query results.
- Prevent repeated expensive work on homepage and in utilities by avoiding unbounded `posts_per_page => -1` and nested loops over large datasets.
- Improve robustness of external fetches by lowering timeouts and adding short-term negative caching to avoid repeated timeouts.

### Description
- Added transient caching for external footer, head and header payloads with positive cache (`10 * MINUTE_IN_SECONDS`) and short negative cache (`2 * MINUTE_IN_SECONDS`) and used cache keys built from `external_home` and `home_url('/')` in `inc/funzionalita_trasversali.php`.
- Reduced remote request `timeout` from `12` to `4` seconds and `redirection` from `5` to `3` for external fetches in `dci_get_external_footer_payload`, `dci_get_external_head_html`, and `dci_get_external_header_html` functions.
- Replaced nested loops in `dci_get_related_bando()` (`inc/utils.php`) with a lookup set built from service IDs to avoid `O(bandi * servizi)` work and early-skip bandi without related servizi, reducing meta accesses inside inner loops.
- Removed unbounded query on homepage by replacing `posts_per_page => -1` with `posts_per_page => $posts_per_page` in `template-parts/home/notizie-auto-evidenza.php` to allow limiting results upstream.
- Added a new audit document `docs/cpu-audit-ultimi-15-giorni.md` describing CPU hotspots and suggested mitigations.

### Testing
- Ran PHP syntax check (`php -l`) on modified files and no syntax errors were reported.
- Performed basic integration smoke tests locally: external header/footer/head fetches returned and were stored in transients and homepage query respects `posts_per_page`; no failures observed.
- No automated unit test suite changes were required for these behavioral optimizations and caching additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4655cf548332921952654eb43fec)