### PR TITLE
Improve caching and robustness for external feeds, appointments and pagination

### DIFF
--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -439,13 +439,13 @@ function dci_get_external_home_snapshot($external_home, $candidate_homes = array
         if (!is_wp_error($response) && wp_remote_retrieve_response_code($response) === 200) {
             $head_html = dci_extract_head_html(wp_remote_retrieve_body($response));
             if (!empty($head_html)) {
-                set_transient($head_cache_key, $head_html, 5 * MINUTE_IN_SECONDS);
+                set_transient($cache_key, array('html' => $head_html), 10 * MINUTE_IN_SECONDS);
                 return $head_html;
             }
         }
     }
 
-    set_transient($head_cache_key, '__empty__', MINUTE_IN_SECONDS);
+    set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
     return '';
 }
 
@@ -537,8 +537,15 @@ function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
         $year = (int) wp_date('Y');
     }
 
+    $cache_key = 'dci_slots_uo_' . $office_id . '_' . $year . '_' . $month;
+    $cached_slots = get_transient($cache_key);
+    if (is_array($cached_slots)) {
+        return $cached_slots;
+    }
+
     $orario_id = absint(dci_get_meta('orario_uo', '_dci_unita_organizzativa_', $office_id));
     if ($orario_id <= 0) {
+        set_transient($cache_key, array(), 2 * MINUTE_IN_SECONDS);
         return array();
     }
 
@@ -549,6 +556,7 @@ function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
     $data_inizio = DateTime::createFromFormat('d-m-Y', $data_inizio_raw) ?: null;
     $data_fine = DateTime::createFromFormat('d-m-Y', $data_fine_raw) ?: null;
     if (!$data_inizio || !$data_fine) {
+        set_transient($cache_key, array(), 2 * MINUTE_IN_SECONDS);
         return array();
     }
 
@@ -609,6 +617,7 @@ function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
         $cursor->modify('+1 day')->setTime(0, 0, 0);
     }
 
+    set_transient($cache_key, $slots, 5 * MINUTE_IN_SECONDS);
     return $slots;
 }
 

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1211,8 +1211,14 @@ if (!function_exists('dci_get_maggioli_services_data')) {
             return $cached_data;
         }
 
+        $lock_key = $cache_key . '_lock';
+        if (get_transient($lock_key)) {
+            return array();
+        }
+        set_transient($lock_key, 1, 20);
+
         $request_args = array(
-            'timeout' => 4,
+            'timeout' => 3,
             'redirection' => 2,
             'sslverify' => false,
             'user-agent' => 'PSR-Theme-Maggioli/1.0 (+'. home_url('/') .')',
@@ -1221,16 +1227,19 @@ if (!function_exists('dci_get_maggioli_services_data')) {
         $response = wp_remote_get($url, $request_args);
         if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
             set_transient($cache_key, array(), 2 * MINUTE_IN_SECONDS);
+            delete_transient($lock_key);
             return array();
         }
 
         $data = json_decode((string) wp_remote_retrieve_body($response), true);
         if (!is_array($data)) {
             set_transient($cache_key, array(), 2 * MINUTE_IN_SECONDS);
+            delete_transient($lock_key);
             return array();
         }
 
         set_transient($cache_key, $data, 5 * MINUTE_IN_SECONDS);
+        delete_transient($lock_key);
         return $data;
     }
 }

--- a/taxonomy-categorie_trasparenza.php
+++ b/taxonomy-categorie_trasparenza.php
@@ -254,8 +254,13 @@ if (!function_exists('dci_render_trasparenza_light_bg_style')) {
 
 dci_render_trasparenza_light_bg_style();
 
-// Recupera il numero di pagina corrente.
-$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+// Recupera il numero di pagina corrente in modo robusto (paged/page/querystring).
+$paged = max(
+    1,
+    (int) get_query_var('paged'),
+    (int) get_query_var('page'),
+    isset($_GET['paged']) ? (int) $_GET['paged'] : 0
+);
 
 $max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 10;
 $load_posts = -1;
@@ -475,7 +480,43 @@ $siti_tematici = !empty(dci_get_option("siti_tematici", "trasparenza")) ? dci_ge
                 </div>
 
                 
-                <?php $pagination_markup = trim((string) dci_bootstrap_pagination($the_query, false)); ?>
+                <?php
+                $pagination_args = array();
+                if ($query !== null && $query !== '') {
+                    $pagination_args['search'] = $query;
+                }
+                if (!empty($order)) {
+                    $pagination_args['order_type'] = $order;
+                }
+                if (!empty($max_posts)) {
+                    $pagination_args['max_posts'] = (int) $max_posts;
+                }
+
+                $pages = paginate_links(array(
+                    'base' => str_replace(999999999, '%#%', esc_url(get_pagenum_link(999999999))),
+                    'format' => '?paged=%#%',
+                    'current' => $paged,
+                    'total' => max(1, (int) $the_query->max_num_pages),
+                    'type' => 'array',
+                    'show_all' => false,
+                    'end_size' => 3,
+                    'mid_size' => 1,
+                    'prev_next' => true,
+                    'prev_text' => __('« '),
+                    'next_text' => __(' »'),
+                    'add_args' => $pagination_args,
+                    'add_fragment' => ''
+                ));
+
+                $pagination_markup = '';
+                if (is_array($pages)) {
+                    $pagination_markup = '<div class="pagination"><ul class="pagination">';
+                    foreach ($pages as $page_link) {
+                        $pagination_markup .= '<li class="page-item' . (strpos($page_link, 'current') !== false ? ' active' : '') . '">' . str_replace('page-numbers', 'page-link', $page_link) . '</li>';
+                    }
+                    $pagination_markup .= '</ul></div>';
+                }
+                ?>
                 <?php if ($pagination_markup !== '') { ?>
                 <div class="row my-4">
                     <div class="col-12 d-flex">

--- a/template-parts/search/item_maggioli.php
+++ b/template-parts/search/item_maggioli.php
@@ -1,30 +1,11 @@
 <?php
 global $post;
 
-// URL remoto da cui ottenere i dati
- $url = dci_get_option('servizi_maggioli_url', 'servizi');
-
-
-// Ottieni i dati dal link remoto
-$response = wp_remote_get($url, array(
-    'timeout' => 4,
-    'redirection' => 2,
-    'sslverify' => false,
-));
-
-// Verifica se la richiesta ha avuto successo
-if (is_wp_error($response)) {
-    echo "Errore durante il recupero dei dati.";
-    return;
-}
-
-$response = wp_remote_retrieve_body($response);
-
-// Decodifica il JSON in un array associativo
-$data = json_decode($response, true);
+// Recupera i dati dal feed (con cache, se disponibile)
+$data = function_exists('dci_get_maggioli_services_data') ? dci_get_maggioli_services_data() : array();
 
 // Controlla se il JSON è stato decodificato correttamente
-if ($data === null) {
+if (!is_array($data)) {
     echo "Errore durante la decodifica del JSON.";
     return;
 }
@@ -79,5 +60,4 @@ foreach ($filtered_data as $item) {
     <?php
 }
 ?>
-
 

--- a/template-parts/servizio/card_maggioli.php
+++ b/template-parts/servizio/card_maggioli.php
@@ -12,12 +12,6 @@ $category_segment = end($segments); // Prendi l'ultimo segmento dell'URL
 // Funzione per ottenere i dati dal servizio web
 function get_procedures_data($search_term = null, $category_segment = null, $title = null)
 {
-    $url = dci_get_option('servizi_maggioli_url', 'servizi');
-    $response = wp_remote_get($url, array(
-        'timeout' => 4,
-        'redirection' => 2,
-        'sslverify' => false,
-    ));
     $total_services = 0; // Inizializza il contatore
     $data = function_exists('dci_get_maggioli_services_data') ? dci_get_maggioli_services_data() : array();
 
@@ -119,4 +113,3 @@ $search_term = isset($_GET['search']) ? $_GET['search'] : null;
 $total_services_loaded = get_procedures_data($search_term, $category_segment, $title);
 echo "<p>Servizi aggiuntivi: $total_services_loaded</p>";
 ?>
-

--- a/template-parts/servizio/servizi_esterni_maggioli.php
+++ b/template-parts/servizio/servizi_esterni_maggioli.php
@@ -2,12 +2,6 @@
 // Funzione per ottenere i dati dal servizio web
 function get_procedures_data($search_term = null)
 {
-    $url = dci_get_option('servizi_maggioli_url', 'servizi');
-    $response = wp_remote_get($url, array(
-        'timeout' => 4,
-        'redirection' => 2,
-        'sslverify' => false,
-    ));
     $total_services = 0; // Inizializza il contatore
     $data = function_exists('dci_get_maggioli_services_data') ? dci_get_maggioli_services_data() : array();
 


### PR DESCRIPTION
### Motivation
- Reduce repeated remote calls and race conditions when fetching external Maggioli service feeds and external head HTML. 
- Cache generated appointment slots to avoid expensive recalculation on every REST request. 
- Fix incorrect transient key usage for external head snapshot and make pagination and page detection more robust.

### Description
- Fix `dci_get_external_home_snapshot()` to use the correct cache key and store an array with an `html` entry, and increase cache lifetimes. 
- Add caching to `dci_get_appuntamenti_ufficio()` with early-return of cached results and cache empty responses for error cases. 
- Add a simple locking transient to `dci_get_maggioli_services_data()` to prevent concurrent fetches, reduce the remote timeout, and ensure the lock is removed on error or success. 
- Update templates (`template-parts/search/item_maggioli.php`, `template-parts/servizio/card_maggioli.php`, `template-parts/servizio/servizi_esterni_maggioli.php`) to use `dci_get_maggioli_services_data()` instead of performing direct `wp_remote_get()` calls and to handle the returned cached array. 
- Improve page-number detection in `taxonomy-categorie_trasparenza.php` by deriving `$paged` from multiple sources and replace the previous `dci_bootstrap_pagination()` usage with `paginate_links()` while preserving search/order/max_posts query args in pagination links.

### Testing
- Ran PHP syntax checks on modified files using `php -l` and the checked files reported no syntax errors. 
- No automated unit tests are present for these changes, so no PHPUnit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a58d21688332bac58520fbb2a0aa)