### PR TITLE
Improve notizia REST fields, Maggioli feed caching, and trasparenza pagination/query alignment

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -794,6 +794,70 @@ add_action('rest_api_init', function () {
         }
     ]);
 
+    register_rest_field('notizia', 'descrizione_completa', [
+        'get_callback' => function ($post) {
+            static $cache = [];
+            if (!isset($cache[$post['id']])) {
+                $cache[$post['id']] = get_post_meta($post['id']);
+            }
+
+            $full_text = $cache[$post['id']]['_dci_notizia_testo_completo'][0] ?? '';
+            if ($full_text === '') {
+                $post_obj = get_post($post['id']);
+                $full_text = $post_obj ? (string) $post_obj->post_content : '';
+            }
+
+            return $full_text;
+        }
+    ]);
+
+    register_rest_field('notizia', 'allegati', [
+        'get_callback' => function ($post) {
+            static $cache = [];
+            if (!isset($cache[$post['id']])) {
+                $cache[$post['id']] = get_post_meta($post['id']);
+            }
+
+            $raw_attachments = $cache[$post['id']]['_dci_notizia_allegati'][0] ?? [];
+            $attachments = maybe_unserialize($raw_attachments);
+            if (!is_array($attachments)) {
+                return [];
+            }
+
+            $result = [];
+            foreach ($attachments as $file_id => $file_data) {
+                $attachment_id = 0;
+                if (is_array($file_data) && isset($file_data['id'])) {
+                    $attachment_id = absint($file_data['id']);
+                } else {
+                    $attachment_id = absint($file_id);
+                }
+
+                $file_url = $attachment_id > 0 ? wp_get_attachment_url($attachment_id) : '';
+                if (empty($file_url) && is_string($file_data)) {
+                    $file_url = $file_data;
+                }
+                if (empty($file_url)) {
+                    continue;
+                }
+
+                $file_name = $attachment_id > 0 ? get_the_title($attachment_id) : basename((string) $file_url);
+                if (empty($file_name)) {
+                    $file_name = basename((string) $file_url);
+                }
+
+                $result[] = [
+                    'id' => $attachment_id,
+                    'nome' => $file_name,
+                    'url_download' => $file_url,
+                    'mime_type' => $attachment_id > 0 ? get_post_mime_type($attachment_id) : '',
+                ];
+            }
+
+            return $result;
+        }
+    ]);
+
     /*
     =====================================
     LUOGO (CACHE)
@@ -888,10 +952,71 @@ add_action('rest_api_init', function () {
 
 });
 
+add_filter('rest_notizia_query', function ($args, $request) {
+    $id = absint($request->get_param('id'));
+    if ($id > 0) {
+        $args['p'] = $id;
+    }
+
+    return $args;
+}, 10, 2);
+
 add_action('save_post_luogo', function($post_id) {
     delete_transient('luogo_meta_' . $post_id);
 });
 
 add_action('update_option_dci_options', function() {
     delete_transient('api_footer');
+});
+
+/**
+ * Allinea la query principale della tassonomia trasparenza ai filtri del template
+ * per evitare mismatch di paginazione (es. ultima pagina in errore/404).
+ */
+add_action('pre_get_posts', function (WP_Query $query) {
+    if (is_admin() || !$query->is_main_query()) {
+        return;
+    }
+
+    if (!$query->is_tax('tipi_cat_amm_trasp')) {
+        return;
+    }
+
+    $max_posts = isset($_GET['max_posts']) ? absint($_GET['max_posts']) : 10;
+    if ($max_posts <= 0) {
+        $max_posts = 10;
+    }
+
+    $search = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : '';
+    $order_type = isset($_GET['order_type']) ? sanitize_key($_GET['order_type']) : 'data_desc';
+
+    $query->set('post_type', 'elemento_trasparenza');
+    $query->set('posts_per_page', $max_posts);
+
+    $term_slug = (string) $query->get('tipi_cat_amm_trasp');
+    if ($term_slug !== '') {
+        $term = get_term_by('slug', $term_slug, 'tipi_cat_amm_trasp');
+        if ($term && !is_wp_error($term)) {
+            $query->set('tax_query', array(
+                array(
+                    'taxonomy' => 'tipi_cat_amm_trasp',
+                    'field' => 'term_id',
+                    'terms' => array((int) $term->term_id),
+                    'include_children' => false,
+                ),
+            ));
+        }
+    }
+
+    if ($search !== '') {
+        $query->set('s', $search);
+    }
+
+    if ($order_type === 'alfabetico_asc' || $order_type === 'alfabetico_desc') {
+        $query->set('orderby', 'title');
+        $query->set('order', $order_type === 'alfabetico_desc' ? 'DESC' : 'ASC');
+    } else {
+        $query->set('orderby', 'date');
+        $query->set('order', $order_type === 'data_asc' ? 'ASC' : 'DESC');
+    }
 });

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -439,13 +439,13 @@ function dci_get_external_home_snapshot($external_home, $candidate_homes = array
         if (!is_wp_error($response) && wp_remote_retrieve_response_code($response) === 200) {
             $head_html = dci_extract_head_html(wp_remote_retrieve_body($response));
             if (!empty($head_html)) {
-                set_transient($head_cache_key, $head_html, 5 * MINUTE_IN_SECONDS);
+                set_transient($cache_key, array('html' => $head_html), 10 * MINUTE_IN_SECONDS);
                 return $head_html;
             }
         }
     }
 
-    set_transient($head_cache_key, '__empty__', MINUTE_IN_SECONDS);
+    set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
     return '';
 }
 
@@ -537,8 +537,15 @@ function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
         $year = (int) wp_date('Y');
     }
 
+    $cache_key = 'dci_slots_uo_' . $office_id . '_' . $year . '_' . $month;
+    $cached_slots = get_transient($cache_key);
+    if (is_array($cached_slots)) {
+        return $cached_slots;
+    }
+
     $orario_id = absint(dci_get_meta('orario_uo', '_dci_unita_organizzativa_', $office_id));
     if ($orario_id <= 0) {
+        set_transient($cache_key, array(), 2 * MINUTE_IN_SECONDS);
         return array();
     }
 
@@ -549,6 +556,7 @@ function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
     $data_inizio = DateTime::createFromFormat('d-m-Y', $data_inizio_raw) ?: null;
     $data_fine = DateTime::createFromFormat('d-m-Y', $data_fine_raw) ?: null;
     if (!$data_inizio || !$data_fine) {
+        set_transient($cache_key, array(), 2 * MINUTE_IN_SECONDS);
         return array();
     }
 
@@ -609,6 +617,7 @@ function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
         $cursor->modify('+1 day')->setTime(0, 0, 0);
     }
 
+    set_transient($cache_key, $slots, 5 * MINUTE_IN_SECONDS);
     return $slots;
 }
 

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1211,8 +1211,14 @@ if (!function_exists('dci_get_maggioli_services_data')) {
             return $cached_data;
         }
 
+        $lock_key = $cache_key . '_lock';
+        if (get_transient($lock_key)) {
+            return array();
+        }
+        set_transient($lock_key, 1, 20);
+
         $request_args = array(
-            'timeout' => 4,
+            'timeout' => 3,
             'redirection' => 2,
             'sslverify' => false,
             'user-agent' => 'PSR-Theme-Maggioli/1.0 (+'. home_url('/') .')',
@@ -1221,16 +1227,19 @@ if (!function_exists('dci_get_maggioli_services_data')) {
         $response = wp_remote_get($url, $request_args);
         if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
             set_transient($cache_key, array(), 2 * MINUTE_IN_SECONDS);
+            delete_transient($lock_key);
             return array();
         }
 
         $data = json_decode((string) wp_remote_retrieve_body($response), true);
         if (!is_array($data)) {
             set_transient($cache_key, array(), 2 * MINUTE_IN_SECONDS);
+            delete_transient($lock_key);
             return array();
         }
 
         set_transient($cache_key, $data, 5 * MINUTE_IN_SECONDS);
+        delete_transient($lock_key);
         return $data;
     }
 }

--- a/taxonomy-categorie_trasparenza.php
+++ b/taxonomy-categorie_trasparenza.php
@@ -254,8 +254,13 @@ if (!function_exists('dci_render_trasparenza_light_bg_style')) {
 
 dci_render_trasparenza_light_bg_style();
 
-// Recupera il numero di pagina corrente.
-$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+// Recupera il numero di pagina corrente in modo robusto (paged/page/querystring).
+$paged = max(
+    1,
+    (int) get_query_var('paged'),
+    (int) get_query_var('page'),
+    isset($_GET['paged']) ? (int) $_GET['paged'] : 0
+);
 
 $max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 10;
 $load_posts = -1;
@@ -266,35 +271,8 @@ $prefix = '_dci_elemento_trasparenza_';
 // Gestione dell'ordinamento
 $order = isset($_GET['order_type']) ? $_GET['order_type'] : 'data_desc'; // Default è data_desc
 
-$args = array(
-    's' => $query,
-    'posts_per_page' => $max_posts,
-    'post_type' => 'elemento_trasparenza',
-    'paged' => $paged,
-    'tax_query' => array(
-        array(
-            'taxonomy' => 'tipi_cat_amm_trasp',
-            'field' => 'term_id',
-            'terms' => array($obj->term_id),
-            'include_children' => false,
-        ),
-    ),
-);
-
-// Gestione dell'ordinamento
-if ($order === 'alfabetico_asc' || $order === 'alfabetico_desc') {
-    $args['orderby'] = 'title';
-    $args['order'] = ($order === 'alfabetico_desc') ? 'DESC' : 'ASC';
-} else {
-    // Ordinamento per data di pubblicazione del post (post_date)
-    $args['orderby'] = 'date';
-    $args['order'] = ($order === 'data_desc') ? 'DESC' : 'ASC';
-}
-
-
-
-$the_query = new WP_Query($args);
-// $pagination_markup = trim((string) dci_bootstrap_pagination());
+global $wp_query;
+$the_query = $wp_query;
 
 
 
@@ -475,7 +453,43 @@ $siti_tematici = !empty(dci_get_option("siti_tematici", "trasparenza")) ? dci_ge
                 </div>
 
                 
-                <?php $pagination_markup = trim((string) dci_bootstrap_pagination($the_query, false)); ?>
+                <?php
+                $pagination_args = array();
+                if ($query !== null && $query !== '') {
+                    $pagination_args['search'] = $query;
+                }
+                if (!empty($order)) {
+                    $pagination_args['order_type'] = $order;
+                }
+                if (!empty($max_posts)) {
+                    $pagination_args['max_posts'] = (int) $max_posts;
+                }
+
+                $pages = paginate_links(array(
+                    'base' => str_replace(999999999, '%#%', esc_url(get_pagenum_link(999999999))),
+                    'format' => '?paged=%#%',
+                    'current' => $paged,
+                    'total' => max(1, (int) $the_query->max_num_pages),
+                    'type' => 'array',
+                    'show_all' => false,
+                    'end_size' => 3,
+                    'mid_size' => 1,
+                    'prev_next' => true,
+                    'prev_text' => __('« '),
+                    'next_text' => __(' »'),
+                    'add_args' => $pagination_args,
+                    'add_fragment' => ''
+                ));
+
+                $pagination_markup = '';
+                if (is_array($pages)) {
+                    $pagination_markup = '<div class="pagination"><ul class="pagination">';
+                    foreach ($pages as $page_link) {
+                        $pagination_markup .= '<li class="page-item' . (strpos($page_link, 'current') !== false ? ' active' : '') . '">' . str_replace('page-numbers', 'page-link', $page_link) . '</li>';
+                    }
+                    $pagination_markup .= '</ul></div>';
+                }
+                ?>
                 <?php if ($pagination_markup !== '') { ?>
                 <div class="row my-4">
                     <div class="col-12 d-flex">

--- a/template-parts/search/item_maggioli.php
+++ b/template-parts/search/item_maggioli.php
@@ -1,30 +1,11 @@
 <?php
 global $post;
 
-// URL remoto da cui ottenere i dati
- $url = dci_get_option('servizi_maggioli_url', 'servizi');
-
-
-// Ottieni i dati dal link remoto
-$response = wp_remote_get($url, array(
-    'timeout' => 4,
-    'redirection' => 2,
-    'sslverify' => false,
-));
-
-// Verifica se la richiesta ha avuto successo
-if (is_wp_error($response)) {
-    echo "Errore durante il recupero dei dati.";
-    return;
-}
-
-$response = wp_remote_retrieve_body($response);
-
-// Decodifica il JSON in un array associativo
-$data = json_decode($response, true);
+// Recupera i dati dal feed (con cache, se disponibile)
+$data = function_exists('dci_get_maggioli_services_data') ? dci_get_maggioli_services_data() : array();
 
 // Controlla se il JSON è stato decodificato correttamente
-if ($data === null) {
+if (!is_array($data)) {
     echo "Errore durante la decodifica del JSON.";
     return;
 }
@@ -79,5 +60,4 @@ foreach ($filtered_data as $item) {
     <?php
 }
 ?>
-
 

--- a/template-parts/servizio/card_maggioli.php
+++ b/template-parts/servizio/card_maggioli.php
@@ -12,12 +12,6 @@ $category_segment = end($segments); // Prendi l'ultimo segmento dell'URL
 // Funzione per ottenere i dati dal servizio web
 function get_procedures_data($search_term = null, $category_segment = null, $title = null)
 {
-    $url = dci_get_option('servizi_maggioli_url', 'servizi');
-    $response = wp_remote_get($url, array(
-        'timeout' => 4,
-        'redirection' => 2,
-        'sslverify' => false,
-    ));
     $total_services = 0; // Inizializza il contatore
     $data = function_exists('dci_get_maggioli_services_data') ? dci_get_maggioli_services_data() : array();
 
@@ -119,4 +113,3 @@ $search_term = isset($_GET['search']) ? $_GET['search'] : null;
 $total_services_loaded = get_procedures_data($search_term, $category_segment, $title);
 echo "<p>Servizi aggiuntivi: $total_services_loaded</p>";
 ?>
-

--- a/template-parts/servizio/servizi_esterni_maggioli.php
+++ b/template-parts/servizio/servizi_esterni_maggioli.php
@@ -2,12 +2,6 @@
 // Funzione per ottenere i dati dal servizio web
 function get_procedures_data($search_term = null)
 {
-    $url = dci_get_option('servizi_maggioli_url', 'servizi');
-    $response = wp_remote_get($url, array(
-        'timeout' => 4,
-        'redirection' => 2,
-        'sslverify' => false,
-    ));
     $total_services = 0; // Inizializza il contatore
     $data = function_exists('dci_get_maggioli_services_data') ? dci_get_maggioli_services_data() : array();
 


### PR DESCRIPTION
### Motivation
- Provide richer REST responses for the `notizia` post type and ensure the API can fetch a single `notizia` by id to support clients. 
- Reduce repeated remote requests to the Maggioli services feed and avoid concurrent fetch storms. 
- Prevent pagination mismatch between frontend filters and the main taxonomy query for trasparenza listings.

### Description
- Added two new REST fields for the `notizia` type: `descrizione_completa` (falls back to `post_content` if meta is empty) and `allegati` (normalizes stored attachment entries into id/name/url/mime entries), and a `rest_notizia_query` filter to allow querying a single post by `id`.
- Implemented a `pre_get_posts` handler to align the main query on the `tipi_cat_amm_trasp` taxonomy with template filters (`max_posts`, `search`, `order_type`) and to set proper ordering and tax_query to avoid pagination 404s.
- Introduced transients and locking for external data: updated `dci_get_maggioli_services_data` to use a short lock (`*_lock`) to avoid parallel fetches and reduced request timeout; added caching for appointment slots in `dci_get_appuntamenti_ufficio` and adjusted caching logic in `dci_get_external_home_snapshot` to store structured cache entries with new durations.
- Reworked trasparenza template pagination to compute `paged` robustly (from `paged`, `page`, or querystring), reuse global `$wp_query`, and build paginate links that preserve current filters (`search`, `order_type`, `max_posts`).
- Updated several service templates (`template-parts/search/item_maggioli.php`, `template-parts/servizio/card_maggioli.php`, and `template-parts/servizio/servizi_esterni_maggioli.php`) to consume the cached Maggioli feed via `dci_get_maggioli_services_data` instead of calling `wp_remote_get` directly.

### Testing
- Performed PHP syntax checks with `php -l` on the modified files and they passed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a58d21688332bac58520fbb2a0aa)