### PR TITLE
Fix paginazione Documenti e Dati: preserva filtro `search` e evita override globale

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -626,10 +626,21 @@ function dci_bootstrap_pagination(?\WP_Query $wp_query = null, $echo = true)
     if ($wp_query === null) {
         global $wp_query;
     }
+
+    $current_page = max(1, (int) get_query_var('paged'));
+    if ($current_page < 2 && isset($_GET['paged'])) {
+        $current_page = max(1, absint($_GET['paged']));
+    }
+
+    $add_args = [];
+    if (isset($_GET['search']) && $_GET['search'] !== '') {
+        $add_args['search'] = dci_removeslashes($_GET['search']);
+    }
+
     $pages = paginate_links([
             'base' => str_replace(999999999, '%#%', esc_url(get_pagenum_link(999999999))),
             'format' => '?paged=%#%',
-            'current' => max(1, get_query_var('paged')),
+            'current' => $current_page,
             'total' => $wp_query->max_num_pages,
             'type' => 'array',
             'show_all' => false,
@@ -638,7 +649,7 @@ function dci_bootstrap_pagination(?\WP_Query $wp_query = null, $echo = true)
             'prev_next' => true,
             'prev_text' => __('« '),
             'next_text' => __(' »'),
-            'add_args' => false,
+            'add_args' => $add_args,
             'add_fragment' => ''
         ]
     );

--- a/template-parts/documento/tutti-documenti.php
+++ b/template-parts/documento/tutti-documenti.php
@@ -20,7 +20,6 @@ $args = array(
 );
 
 $the_query = new WP_Query($args);
-$GLOBALS['wp_query'] = $the_query;
 ?>
 
 <div class="bg-grey-card py-5">
@@ -69,7 +68,7 @@ $GLOBALS['wp_query'] = $the_query;
       <?php if ($the_query->max_num_pages > 1) : ?>
       <div class="row my-4">
           <nav class="pagination-wrapper justify-content-center col-12" aria-label="Navigazione pagine documenti">
-              <?php echo dci_bootstrap_pagination(); ?>
+              <?php dci_bootstrap_pagination($the_query); ?>
           </nav>
       </div>
       <?php endif; ?>


### PR DESCRIPTION
### Motivation
- Risolvere comportamenti erratici della paginazione nella sezione Documenti e Dati che causavano mismatch della pagina corrente e perdita del filtro di ricerca.
- Evitare l'override del `GLOBALS['wp_query']` per ridurre effetti collaterali e overhead derivante dall'uso della query globale.
- Garantire che i link di paginazione mantengano i parametri di ricerca per evitare ricariche inutili e perdita del contesto utente.

### Description
- Calcolo robusto della pagina corrente in `dci_bootstrap_pagination()` usando sia `get_query_var('paged')` sia `$_GET['paged']` e assegnando il valore a `
  $current_page` per evitare mismatch in template pagina.
- Preservazione del parametro di ricerca passando `add_args` a `paginate_links()` quando `$_GET['search']` è presente e sanificato con `dci_removeslashes()`.
- Rimozione della sovrascrittura di `$GLOBALS['wp_query']` nel template `template-parts/documento/tutti-documenti.php` e passaggio esplicito della query custom a `dci_bootstrap_pagination($the_query)`.
- File modificati: `inc/utils.php` e `template-parts/documento/tutti-documenti.php`.

### Testing
- Eseguiti i controlli di sintassi con `php -l template-parts/documento/tutti-documenti.php` e `php -l inc/utils.php`, entrambi passati con esito positivo.
- Nessun test automatico aggiuntivo presente nel repository è stato eseguito durante questa modifica.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22bc702748332bb48cbbe45379a6c)