### PR TITLE
Improve pagination: preserve query params and robust paged handling

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -626,10 +626,31 @@ function dci_bootstrap_pagination(?\WP_Query $wp_query = null, $echo = true)
     if ($wp_query === null) {
         global $wp_query;
     }
+
+    $current_page = max(1, (int) get_query_var('paged'), (int) get_query_var('page'));
+    if ($current_page < 2 && isset($_GET['paged'])) {
+        $current_page = max(1, absint($_GET['paged']));
+    }
+    if ($current_page < 2 && isset($_GET['page'])) {
+        $current_page = max(1, absint($_GET['page']));
+    }
+
+    $add_args = [];
+    if (!empty($_GET) && is_array($_GET)) {
+        foreach ($_GET as $key => $value) {
+            if (in_array($key, ['paged', 'page'], true)) {
+                continue;
+            }
+            if (is_scalar($value) && $value !== '') {
+                $add_args[$key] = dci_removeslashes((string) $value);
+            }
+        }
+    }
+
     $pages = paginate_links([
             'base' => str_replace(999999999, '%#%', esc_url(get_pagenum_link(999999999))),
             'format' => '?paged=%#%',
-            'current' => max(1, get_query_var('paged')),
+            'current' => $current_page,
             'total' => $wp_query->max_num_pages,
             'type' => 'array',
             'show_all' => false,
@@ -638,7 +659,7 @@ function dci_bootstrap_pagination(?\WP_Query $wp_query = null, $echo = true)
             'prev_next' => true,
             'prev_text' => __('« '),
             'next_text' => __(' »'),
-            'add_args' => false,
+            'add_args' => $add_args,
             'add_fragment' => ''
         ]
     );

--- a/template-parts/amministrazione-trasparente/atto-concessione/tutti-gli-atti.php
+++ b/template-parts/amministrazione-trasparente/atto-concessione/tutti-gli-atti.php
@@ -4,7 +4,10 @@ global $wpdb;
 // Lettura parametri da URL
 $max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 10;
 $main_search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
-$paged = isset($_GET['page']) ? max(1, intval($_GET['page'])) : 1;
+$paged = max(1, (int) get_query_var('paged'));
+if ($paged < 2) {
+    $paged = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : (isset($_GET['page']) ? max(1, intval($_GET['page'])) : 1);
+}
 $selected_year = isset($_GET['filter_year']) ? intval($_GET['filter_year']) : 0;
 
 // Anni disponibili
@@ -39,12 +42,6 @@ if ($selected_year > 0) {
 
 $the_query = new WP_Query($args);
 
-// URL base per la paginazione
-
-
-// Query personalizzata
-$the_query = new WP_Query($args);
-
 // Prendi permalink pagina corrente (senza query string)
 $current_url = get_permalink();
 
@@ -53,7 +50,7 @@ $base_url = add_query_arg(array(
     'search'      => $main_search_query ? $main_search_query : '',
     'filter_year' => $selected_year > 0 ? $selected_year : 0,
     'max_posts'   => $max_posts,
-    'page'        => '%#%',
+    'paged'       => '%#%',
 ), $current_url);
 
 

--- a/template-parts/amministrazione-trasparente/incarichi-autorizzazioni/tutti-gli-incarichi.php
+++ b/template-parts/amministrazione-trasparente/incarichi-autorizzazioni/tutti-gli-incarichi.php
@@ -6,7 +6,10 @@ global $wpdb;
 
 $max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 5;
 $main_search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
-$paged = isset($_GET['page']) ? max(1, intval($_GET['page'])) : 1;
+$paged = max(1, (int) get_query_var('paged'));
+if ($paged < 2) {
+    $paged = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : (isset($_GET['page']) ? max(1, intval($_GET['page'])) : 1);
+}
 $selected_year = isset($_GET['filter_year']) ? intval($_GET['filter_year']) : 0;
 
 // Prendi gli anni disponibili dai post pubblicati (per la combo)
@@ -50,7 +53,7 @@ $base_url = add_query_arg(array(
     'search'      => $main_search_query ? $main_search_query : '',
     'filter_year' => $selected_year > 0 ? $selected_year : 0,
     'max_posts'   => $max_posts,
-    'page'        => '%#%',
+    'paged'       => '%#%',
 ), $current_url);
 ?>
 

--- a/template-parts/documento/tutti-documenti.php
+++ b/template-parts/documento/tutti-documenti.php
@@ -20,7 +20,6 @@ $args = array(
 );
 
 $the_query = new WP_Query($args);
-$GLOBALS['wp_query'] = $the_query;
 ?>
 
 <div class="bg-grey-card py-5">
@@ -69,7 +68,7 @@ $GLOBALS['wp_query'] = $the_query;
       <?php if ($the_query->max_num_pages > 1) : ?>
       <div class="row my-4">
           <nav class="pagination-wrapper justify-content-center col-12" aria-label="Navigazione pagine documenti">
-              <?php echo dci_bootstrap_pagination(); ?>
+              <?php dci_bootstrap_pagination($the_query); ?>
           </nav>
       </div>
       <?php endif; ?>


### PR DESCRIPTION
### Motivation

- Fix inconsistent pagination behavior by reliably detecting the current page from both WP query vars and GET parameters and preserve other query parameters across pagination links. 

### Description

- Update `dci_bootstrap_pagination()` to compute `current` page from `get_query_var('paged')`/`get_query_var('page')` and fall back to `$_GET['paged']`/`$_GET['page']`, and to collect other scalar `$_GET` parameters into `add_args` while excluding pagination keys.  
- Change template files to use `max(1, (int) get_query_var('paged'))` with fallbacks to `$_GET['paged']`/`$_GET['page']` when needed to ensure consistent paging across contexts.  
- Use the `paged` query var consistently in pagination base URLs (`'paged' => '%#%'`) and update calls to `dci_bootstrap_pagination()` to pass the custom `WP_Query` instance (e.g. `dci_bootstrap_pagination($the_query)`).  
- Clean up duplicate query instantiation and normalize parameter names in multiple template parts to ensure preserved filters and correct pagination links.

### Testing

- Ran PHP syntax checks on modified files using `php -l` and there were no parse errors.  
- Executed the existing PHPUnit suite (`phpunit`) and the tests covering pagination and templates passed.  
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22bc702748332bb48cbbe45379a6c)