### PR TITLE
Hide offices without services in booking form

### DIFF
--- a/template-parts/prenotazione/content.php
+++ b/template-parts/prenotazione/content.php
@@ -13,6 +13,20 @@
                 'value' => '',
                 'compare' => '!=',
             ),
+            array(
+                'key' => '_dci_unita_organizzativa_elenco_servizi_offerti',
+                'compare' => 'EXISTS',
+            ),
+            array(
+                'key' => '_dci_unita_organizzativa_elenco_servizi_offerti',
+                'value' => '',
+                'compare' => '!=',
+            ),
+            array(
+                'key' => '_dci_unita_organizzativa_elenco_servizi_offerti',
+                'value' => 'a:0:{}',
+                'compare' => '!=',
+            ),
         ),
     ));
 


### PR DESCRIPTION
### Motivation
- Avoid showing organizational units in the booking workflow that have no services linked, because they lead to an empty "Motivo" step and a broken UX.

### Description
- Restrict the initial office query in `template-parts/prenotazione/content.php` by adding meta-query clauses to require `_dci_unita_organizzativa_elenco_servizi_offerti` to exist and be non-empty and not equal to the serialized empty array `a:0:{}`.
- The change keeps the existing checks for `_dci_unita_organizzativa_orario_uo` and only returns units that also have at least one linked service.

### Testing
- Ran PHP lint on the modified file with `php -l template-parts/prenotazione/content.php` which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b13b68e883329205b2fb239ec03b)