### PR TITLE
Do not cache current-month appointment slots and exclude offices without services

### DIFF
--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -537,10 +537,14 @@ function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
         $year = (int) wp_date('Y');
     }
 
+    $is_current_month = ((int) wp_date('n') === $month && (int) wp_date('Y') === $year);
     $cache_key = 'dci_slots_uo_' . $office_id . '_' . $year . '_' . $month;
-    $cached_slots = get_transient($cache_key);
-    if (is_array($cached_slots)) {
-        return $cached_slots;
+
+    if (!$is_current_month) {
+        $cached_slots = get_transient($cache_key);
+        if (is_array($cached_slots)) {
+            return $cached_slots;
+        }
     }
 
     $orario_id = absint(dci_get_meta('orario_uo', '_dci_unita_organizzativa_', $office_id));
@@ -617,7 +621,10 @@ function dci_get_appuntamenti_ufficio(WP_REST_Request $request) {
         $cursor->modify('+1 day')->setTime(0, 0, 0);
     }
 
-    set_transient($cache_key, $slots, 5 * MINUTE_IN_SECONDS);
+    if (!$is_current_month) {
+        set_transient($cache_key, $slots, 5 * MINUTE_IN_SECONDS);
+    }
+
     return $slots;
 }
 

--- a/template-parts/prenotazione/content.php
+++ b/template-parts/prenotazione/content.php
@@ -13,6 +13,20 @@
                 'value' => '',
                 'compare' => '!=',
             ),
+            array(
+                'key' => '_dci_unita_organizzativa_elenco_servizi_offerti',
+                'compare' => 'EXISTS',
+            ),
+            array(
+                'key' => '_dci_unita_organizzativa_elenco_servizi_offerti',
+                'value' => '',
+                'compare' => '!=',
+            ),
+            array(
+                'key' => '_dci_unita_organizzativa_elenco_servizi_offerti',
+                'value' => 'a:0:{}',
+                'compare' => '!=',
+            ),
         ),
     ));
 


### PR DESCRIPTION
### Motivation
- Ensure appointment slots for the current month are always fresh by avoiding cache read/write for the current month.
- Prevent units without offered services from being listed in the booking UI by filtering them out at query time.

### Description
- In `dci_get_appuntamenti_ufficio` introduced `$is_current_month` and skipped `get_transient`/`set_transient` when the requested month/year is the current month to avoid stale slot data.
- Kept caching behavior for past/future months by using the existing transient key `dci_slots_uo_{id}_{year}_{month}` with a 5-minute TTL for non-current months.
- In `template-parts/prenotazione/content.php` added meta query checks for `_dci_unita_organizzativa_elenco_servizi_offerti` to ensure the meta exists, is not empty, and is not the serialized empty array `a:0:{}`.

### Testing
- Ran PHP syntax check (`php -l`) on the modified files and it passed without syntax errors.
- There are no automated unit tests covering these specific functions in the repository, so no unit test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b13b68e883329205b2fb239ec03b)