### PR TITLE
Aggiunge endpoint REST per servizi attivi

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -732,9 +732,84 @@ add_action('init', function() {
 });
 
 
+
+
+/**
+ * Restituisce i servizi attivi per integrazioni esterne (es. APP Comuni).
+ */
+function dci_is_servizio_attivo($post_id) {
+    $prefix = '_dci_servizio_';
+    $stato = get_post_meta($post_id, $prefix . 'stato', true);
+
+    if ($stato === 'false') {
+        return false;
+    }
+
+    $today = current_time('Y-m-d');
+
+    $data_inizio_raw = trim((string) get_post_meta($post_id, $prefix . 'data_inizio_servizio', true));
+    if ($data_inizio_raw !== '') {
+        $data_inizio = DateTime::createFromFormat('d/m/Y', $data_inizio_raw);
+        if ($data_inizio instanceof DateTime && $data_inizio->format('Y-m-d') > $today) {
+            return false;
+        }
+    }
+
+    $data_fine_raw = trim((string) get_post_meta($post_id, $prefix . 'data_fine_servizio', true));
+    if ($data_fine_raw !== '') {
+        $data_fine = DateTime::createFromFormat('d/m/Y', $data_fine_raw);
+        if ($data_fine instanceof DateTime && $data_fine->format('Y-m-d') < $today) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function dci_get_servizi_attivi_rest_payload(WP_REST_Request $request) {
+    $limit = (int) $request->get_param('per_page');
+    if ($limit <= 0 || $limit > 200) {
+        $limit = 100;
+    }
+
+    $servizi = get_posts([
+        'post_type' => 'servizio',
+        'post_status' => 'publish',
+        'posts_per_page' => $limit,
+        'orderby' => 'title',
+        'order' => 'ASC',
+    ]);
+
+    $response = [];
+
+    foreach ($servizi as $servizio) {
+        if (!dci_is_servizio_attivo($servizio->ID)) {
+            continue;
+        }
+
+        $response[] = [
+            'id' => $servizio->ID,
+            'titolo' => get_the_title($servizio->ID),
+            'slug' => $servizio->post_name,
+            'link' => get_permalink($servizio->ID),
+            'descrizione_breve' => (string) get_post_meta($servizio->ID, '_dci_servizio_descrizione_breve', true),
+            'data_inizio_servizio' => (string) get_post_meta($servizio->ID, '_dci_servizio_data_inizio_servizio', true),
+            'data_fine_servizio' => (string) get_post_meta($servizio->ID, '_dci_servizio_data_fine_servizio', true),
+        ];
+    }
+
+    return rest_ensure_response($response);
+}
 add_action('rest_api_init', function () {
 
-    /*
+    
+    register_rest_route('comune/v1', '/servizi-attivi', [
+        'methods'  => WP_REST_Server::READABLE,
+        'callback' => 'dci_get_servizi_attivi_rest_payload',
+        'permission_callback' => '__return_true',
+    ]);
+
+/*
     =====================================
     EVENTO (OTTIMIZZATO)
     =====================================


### PR DESCRIPTION
### Motivation
- Fornire un endpoint REST pubblico per permettere ad integrazioni esterne (es. APP Comuni) di recuperare rapidamente l’elenco dei servizi effettivamente attivi senza impattare il front-end.
- Rendere il filtro dei servizi coerente con la logica già presente in admin (`_dci_servizio_stato`, `data_inizio`, `data_fine`) in modo sicuro per l’ambiente di produzione.

### Description
- Aggiunta della funzione `dci_is_servizio_attivo($post_id)` che valuta lo stato del servizio leggendo `_dci_servizio_stato`, `_dci_servizio_data_inizio_servizio` e `_dci_servizio_data_fine_servizio` con parsing `d/m/Y` usando `DateTime`.
- Aggiunta della funzione `dci_get_servizi_attivi_rest_payload(WP_REST_Request $request)` che recupera i post di tipo `servizio`, filtra quelli attivi e costruisce un payload leggero con `id`, `titolo`, `slug`, `link`, `descrizione_breve`, `data_inizio_servizio` e `data_fine_servizio`.
- Registrato l’endpoint pubblico `GET /wp-json/comune/v1/servizi-attivi` nello stesso namespace `comune/v1` e aggiunto supporto al parametro `per_page` (default `100`, max `200`).
- Modifica limitata al layer API senza cambiamenti a template o interfaccia utente.

### Testing
- Eseguito controllo di sintassi PHP con `php -l functions.php` che è passato con esito positivo.
- Commit del file aggiornato eseguito con successo (`git commit`).
- Nessun altro test automatico disponibile è stato eseguito in questo rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc64106c648332a7dce59ca8249277)