### PR TITLE
Expose active servizi via REST endpoints and add helper functions

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -732,9 +732,91 @@ add_action('init', function() {
 });
 
 
+
+
+/**
+ * Restituisce i servizi attivi per integrazioni esterne (es. APP Comuni).
+ */
+function dci_is_servizio_attivo($post_id) {
+    $prefix = '_dci_servizio_';
+    $stato = get_post_meta($post_id, $prefix . 'stato', true);
+
+    if ($stato === 'false') {
+        return false;
+    }
+
+    $today = current_time('Y-m-d');
+
+    $data_inizio_raw = trim((string) get_post_meta($post_id, $prefix . 'data_inizio_servizio', true));
+    if ($data_inizio_raw !== '') {
+        $data_inizio = DateTime::createFromFormat('d/m/Y', $data_inizio_raw);
+        if ($data_inizio instanceof DateTime && $data_inizio->format('Y-m-d') > $today) {
+            return false;
+        }
+    }
+
+    $data_fine_raw = trim((string) get_post_meta($post_id, $prefix . 'data_fine_servizio', true));
+    if ($data_fine_raw !== '') {
+        $data_fine = DateTime::createFromFormat('d/m/Y', $data_fine_raw);
+        if ($data_fine instanceof DateTime && $data_fine->format('Y-m-d') < $today) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function dci_get_servizi_attivi_rest_payload(WP_REST_Request $request) {
+    $limit = (int) $request->get_param('per_page');
+    if ($limit <= 0 || $limit > 200) {
+        $limit = 100;
+    }
+
+    $servizi = get_posts([
+        'post_type' => 'servizio',
+        'post_status' => 'publish',
+        'posts_per_page' => $limit,
+        'orderby' => 'title',
+        'order' => 'ASC',
+    ]);
+
+    $response = [];
+
+    foreach ($servizi as $servizio) {
+        if (!dci_is_servizio_attivo($servizio->ID)) {
+            continue;
+        }
+
+        $response[] = [
+            'id' => $servizio->ID,
+            'titolo' => get_the_title($servizio->ID),
+            'slug' => $servizio->post_name,
+            'link' => get_permalink($servizio->ID),
+            'descrizione_breve' => (string) get_post_meta($servizio->ID, '_dci_servizio_descrizione_breve', true),
+            'data_inizio_servizio' => (string) get_post_meta($servizio->ID, '_dci_servizio_data_inizio_servizio', true),
+            'data_fine_servizio' => (string) get_post_meta($servizio->ID, '_dci_servizio_data_fine_servizio', true),
+        ];
+    }
+
+    return rest_ensure_response($response);
+}
 add_action('rest_api_init', function () {
 
-    /*
+    
+    register_rest_route('comune/v1', '/servizi-attivi', [
+        'methods'  => WP_REST_Server::READABLE,
+        'callback' => 'dci_get_servizi_attivi_rest_payload',
+        'permission_callback' => '__return_true',
+    ]);
+
+    // Alias per compatibilità con integrazioni che usano namespace wp/v1.
+    register_rest_route('wp/v1', '/servizi-attivi', [
+        'methods'  => WP_REST_Server::READABLE,
+        'callback' => 'dci_get_servizi_attivi_rest_payload',
+        'permission_callback' => '__return_true',
+    ]);
+
+/*
     =====================================
     EVENTO (OTTIMIZZATO)
     =====================================


### PR DESCRIPTION
### Motivation

- Provide a REST-friendly listing of currently active `servizio` posts to support external integrations (e.g. municipal apps). 

### Description

- Add `dci_is_servizio_attivo()` to determine whether a `servizio` is active based on `_dci_servizio_stato` and optional start/end dates parsed as `d/m/Y`.
- Add `dci_get_servizi_attivi_rest_payload(WP_REST_Request $request)` to return a capped (default 100, max 200) alphabetical list of active services with `id`, `titolo`, `slug`, `link`, `descrizione_breve`, `data_inizio_servizio`, and `data_fine_servizio`.
- Register REST routes `comune/v1/servizi-attivi` and `wp/v1/servizi-attivi` with `permission_callback` set to `__return_true` and the above callback.
- Keep payload generation server-side and skip services that are not active according to the helper function.

### Testing

- Performed a PHP syntax check on the modified file with `php -l functions.php`, which passed.
- No new automated unit tests were added for the REST endpoints in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc64106c648332a7dce59ca8249277)