### PR TITLE
Aggiungi API REST per amministrazione politica e responsabili degli uffici

### DIFF
--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -84,6 +84,30 @@ function dci_register_servizi_ufficio_route() {
 add_action('rest_api_init', 'dci_register_servizi_ufficio_route');
 
 /**
+ * Espone i titolari dell'amministrazione politica con ruoli e dati essenziali.
+ */
+function dci_register_amministrazione_politica_route() {
+    register_rest_route('wp/v2', '/amministrazione-politica/', array(
+        'methods' => 'GET',
+        'callback' => 'dci_get_amministrazione_politica',
+        'permission_callback' => '__return_true',
+    ));
+}
+add_action('rest_api_init', 'dci_register_amministrazione_politica_route');
+
+/**
+ * Espone gli uffici e i relativi responsabili (se presenti).
+ */
+function dci_register_uffici_responsabili_route() {
+    register_rest_route('wp/v2', '/uffici/responsabili/', array(
+        'methods' => 'GET',
+        'callback' => 'dci_get_uffici_responsabili',
+        'permission_callback' => '__return_true',
+    ));
+}
+add_action('rest_api_init', 'dci_register_uffici_responsabili_route');
+
+/**
  * Espone gli slot prenotabili costruiti dall'orario associato all'Unità organizzativa.
  */
 function dci_register_appuntamenti_ufficio_route() {
@@ -756,6 +780,136 @@ function dci_get_servizi_ufficio(WP_REST_Request $request) {
     }
 
     return $servizi;
+}
+
+/**
+ * Normalizza una lista di ID salvata in meta (array/stringa/scalare).
+ *
+ * @param mixed $value
+ * @return int[]
+ */
+function dci_normalize_meta_ids($value) {
+    if (empty($value)) {
+        return array();
+    }
+
+    if (!is_array($value)) {
+        $value = array($value);
+    }
+
+    return array_values(array_unique(array_filter(array_map('intval', $value))));
+}
+
+/**
+ * Restituisce i titolari dell'amministrazione politica con ruoli, immagine e descrizione breve.
+ *
+ * @param WP_REST_Request $request
+ * @return array[]
+ */
+function dci_get_amministrazione_politica(WP_REST_Request $request) {
+    $people = get_posts(array(
+        'post_type' => 'persona_pubblica',
+        'post_status' => 'publish',
+        'numberposts' => -1,
+        'orderby' => 'title',
+        'order' => 'ASC',
+    ));
+
+    $response = array();
+
+    foreach ($people as $person) {
+        $incarichi_ids = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person->ID));
+        if (empty($incarichi_ids)) {
+            continue;
+        }
+
+        $ruoli = array();
+        foreach ($incarichi_ids as $incarico_id) {
+            $incarico = get_post($incarico_id);
+            if ($incarico instanceof WP_Post && $incarico->post_status === 'publish') {
+                $ruoli[] = $incarico->post_title;
+            }
+        }
+
+        if (empty($ruoli)) {
+            continue;
+        }
+
+        $thumbnail_id = get_post_thumbnail_id($person->ID);
+
+        $response[] = array(
+            'id' => $person->ID,
+            'nome' => get_the_title($person->ID),
+            'url' => get_permalink($person->ID),
+            'ruoli' => array_values(array_unique($ruoli)),
+            'descrizione_breve' => dci_get_meta('descrizione_breve', '_dci_persona_pubblica_', $person->ID),
+            'immagine' => $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null,
+        );
+    }
+
+    return $response;
+}
+
+/**
+ * Restituisce gli uffici (unità organizzative) con i rispettivi responsabili se presenti.
+ *
+ * @param WP_REST_Request $request
+ * @return array[]
+ */
+function dci_get_uffici_responsabili(WP_REST_Request $request) {
+    $uffici = get_posts(array(
+        'post_type' => 'unita_organizzativa',
+        'post_status' => 'publish',
+        'numberposts' => -1,
+        'orderby' => 'title',
+        'order' => 'ASC',
+        'tax_query' => array(
+            array(
+                'taxonomy' => 'tipi_unita_organizzativa',
+                'field' => 'slug',
+                'terms' => array('ufficio'),
+            ),
+        ),
+    ));
+
+    $response = array();
+
+    foreach ($uffici as $ufficio) {
+        $responsabili_ids = dci_normalize_meta_ids(dci_get_meta('responsabile', '_dci_unita_organizzativa_', $ufficio->ID));
+        $responsabili = array();
+
+        foreach ($responsabili_ids as $responsabile_id) {
+            $responsabile = get_post($responsabile_id);
+            if (!$responsabile instanceof WP_Post || $responsabile->post_status !== 'publish') {
+                continue;
+            }
+
+            $ruoli = array();
+            $incarichi_ids = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $responsabile_id));
+            foreach ($incarichi_ids as $incarico_id) {
+                $incarico = get_post($incarico_id);
+                if ($incarico instanceof WP_Post && $incarico->post_status === 'publish') {
+                    $ruoli[] = $incarico->post_title;
+                }
+            }
+
+            $responsabili[] = array(
+                'id' => $responsabile_id,
+                'nome' => get_the_title($responsabile_id),
+                'url' => get_permalink($responsabile_id),
+                'ruoli' => array_values(array_unique($ruoli)),
+            );
+        }
+
+        $response[] = array(
+            'id' => $ufficio->ID,
+            'nome' => $ufficio->post_title,
+            'url' => get_permalink($ufficio->ID),
+            'responsabili' => $responsabili,
+        );
+    }
+
+    return $response;
 }
 
 


### PR DESCRIPTION
### Motivation
- Fornire endpoint pubblici che espongano i titolari di incarichi politici e l'elenco degli uffici con i rispettivi responsabili, seguendo l'esempio dell'API `servizi` già presente. 
- Rendere disponibili dati utili per integrazioni esterne (nome, permalink, ruoli, descrizione breve e immagine se presente) in modo coerente con le API esistenti.

### Description
- Aggiunti due endpoint REST pubblici: `GET /wp-json/wp/v2/amministrazione-politica/` e `GET /wp-json/wp/v2/uffici/responsabili/` registrati in `inc/funzionalita_trasversali.php` con `permission_callback => __return_true`.
- Implementata la funzione `dci_get_amministrazione_politica()` che restituisce per ogni `persona_pubblica` pubblicata gli `id`, `nome`, `url`, `ruoli` (derivati dagli `incarichi` collegati), `descrizione_breve` e l'URL dell'`immagine` in evidenza se presente.
- Implementata la funzione `dci_get_uffici_responsabili()` che elenca i post di tipo `unita_organizzativa` con tipologia `ufficio` e, per ciascuno, i `responsabili` (id, nome, url e ruoli).
- Introdotto l'helper `dci_normalize_meta_ids()` per normalizzare in sicurezza valori meta che possono essere array/scalari/stringhe, riducendo il rischio di errori dovuti a dati sporchi.

### Testing
- Eseguito controllo di sintassi PHP con `php -l inc/funzionalita_trasversali.php` e il file è risultato senza errori (successo). 
- Verificata l'integrazione manuale negli script di registrazione delle route insieme alle API esistenti (no test automatici unitari disponibili nel repository).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9d85ac08833282433d9e7151064f)