### PR TITLE
Filter political roles to active terms, add photo URL, and update cache key

### DIFF
--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -817,16 +817,51 @@ function dci_normalize_meta_ids($value) {
  * @return array[]
  */
 function dci_get_amministrazione_politica(WP_REST_Request $request) {
-    $cache_key = 'dci_api_amministrazione_politica_v2';
+    $cache_key = 'dci_api_amministrazione_politica_v5';
     $cached = get_transient($cache_key);
     if (is_array($cached)) {
         return $cached;
     }
 
+    $incarichi_politici = get_posts(array(
+        'post_type' => 'incarico',
+        'post_status' => 'publish',
+        'posts_per_page' => -1,
+        'orderby' => 'title',
+        'order' => 'ASC',
+        'tax_query' => array(
+            array(
+                'taxonomy' => 'tipi_incarico',
+                'field' => 'slug',
+                'terms' => array('politico'),
+            ),
+        ),
+    ));
+
+    $today_ts = current_time('timestamp');
+    $incarichi_politici_attivi = array();
+
+    foreach ($incarichi_politici as $incarico) {
+        $data_fine_incarico = dci_get_meta('data_conclusione_incarico', '_dci_incarico_', $incarico->ID);
+        if (!empty($data_fine_incarico)) {
+            $data_fine_ts = is_numeric($data_fine_incarico) ? intval($data_fine_incarico) : strtotime($data_fine_incarico);
+            if ($data_fine_ts && $data_fine_ts < $today_ts) {
+                continue;
+            }
+        }
+
+        $incarichi_politici_attivi[$incarico->ID] = $incarico->post_title;
+    }
+
+    if (empty($incarichi_politici_attivi)) {
+        set_transient($cache_key, array(), 5 * MINUTE_IN_SECONDS);
+        return array();
+    }
+
     $people = get_posts(array(
         'post_type' => 'persona_pubblica',
         'post_status' => 'publish',
-        'numberposts' => -1,
+        'posts_per_page' => -1,
         'orderby' => 'title',
         'order' => 'ASC',
     ));
@@ -834,19 +869,27 @@ function dci_get_amministrazione_politica(WP_REST_Request $request) {
     $response = array();
 
     foreach ($people as $person) {
-        $incarichi_ids = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person->ID));
-        if (empty($incarichi_ids)) {
+        $data_conclusione_persona = dci_get_meta('data_conclusione_incarico', '_dci_persona_pubblica_', $person->ID);
+        if (!empty($data_conclusione_persona)) {
+            $data_conclusione_persona_ts = is_numeric($data_conclusione_persona) ? intval($data_conclusione_persona) : strtotime($data_conclusione_persona);
+            if ($data_conclusione_persona_ts && $data_conclusione_persona_ts < $today_ts) {
+                continue;
+            }
+        }
+
+        $incarichi_persona = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person->ID));
+        if (empty($incarichi_persona)) {
             continue;
         }
 
         $ruoli = array();
-        foreach ($incarichi_ids as $incarico_id) {
-            $incarico = get_post($incarico_id);
-            if ($incarico instanceof WP_Post && $incarico->post_status === 'publish') {
-                $ruoli[] = $incarico->post_title;
+        foreach ($incarichi_persona as $incarico_id) {
+            if (isset($incarichi_politici_attivi[$incarico_id])) {
+                $ruoli[] = $incarichi_politici_attivi[$incarico_id];
             }
         }
 
+        $ruoli = array_values(array_unique($ruoli));
         if (empty($ruoli)) {
             continue;
         }
@@ -860,9 +903,10 @@ function dci_get_amministrazione_politica(WP_REST_Request $request) {
             'id' => $person->ID,
             'nome' => get_the_title($person->ID),
             'url' => get_permalink($person->ID),
-            'ruoli' => array_values(array_unique($ruoli)),
+            'ruoli' => $ruoli,
             'descrizione_breve' => dci_get_meta('descrizione_breve', '_dci_persona_pubblica_', $person->ID),
             'immagine' => $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null,
+            'url_foto' => $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null,
             'contatti' => $contatti,
         );
     }


### PR DESCRIPTION
### Motivation
- Ensure the `dci_get_amministrazione_politica` endpoint only returns currently active political roles and people and to bump the cache version after behavior changes.

### Description
- Update cache key to `dci_api_amministrazione_politica_v5` and short-circuit to an empty transient when no active political roles are found.
- Query `incarico` posts with `tipi_incarico = politico` and filter out roles whose `data_conclusione_incarico` is in the past, building a map of active role IDs to titles.
- Exclude `persona_pubblica` entries whose `data_conclusione_incarico` has passed and only include roles linked to currently active political `incarico` posts, deduplicating role names.
- Normalize use of `posts_per_page` instead of `numberposts` and add a new `url_foto` field (same URL as `immagine`) to the response.

### Testing
- Ran `php -l` syntax check on the modified file which passed.
- Executed the project's `phpunit` suite where configured and observed all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aecda39fc83329810cf2dc633f402)