### PR TITLE
Filter and cache active political roles in `dci_get_amministrazione_politica`, improve image fallback

### DIFF
--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -817,16 +817,51 @@ function dci_normalize_meta_ids($value) {
  * @return array[]
  */
 function dci_get_amministrazione_politica(WP_REST_Request $request) {
-    $cache_key = 'dci_api_amministrazione_politica_v2';
+    $cache_key = 'dci_api_amministrazione_politica_v5';
     $cached = get_transient($cache_key);
     if (is_array($cached)) {
         return $cached;
     }
 
+    $incarichi_politici = get_posts(array(
+        'post_type' => 'incarico',
+        'post_status' => 'publish',
+        'posts_per_page' => -1,
+        'orderby' => 'title',
+        'order' => 'ASC',
+        'tax_query' => array(
+            array(
+                'taxonomy' => 'tipi_incarico',
+                'field' => 'slug',
+                'terms' => array('politico'),
+            ),
+        ),
+    ));
+
+    $today_ts = current_time('timestamp');
+    $incarichi_politici_attivi = array();
+
+    foreach ($incarichi_politici as $incarico) {
+        $data_fine_incarico = dci_get_meta('data_conclusione_incarico', '_dci_incarico_', $incarico->ID);
+        if (!empty($data_fine_incarico)) {
+            $data_fine_ts = is_numeric($data_fine_incarico) ? intval($data_fine_incarico) : strtotime($data_fine_incarico);
+            if ($data_fine_ts && $data_fine_ts < $today_ts) {
+                continue;
+            }
+        }
+
+        $incarichi_politici_attivi[$incarico->ID] = $incarico->post_title;
+    }
+
+    if (empty($incarichi_politici_attivi)) {
+        set_transient($cache_key, array(), 5 * MINUTE_IN_SECONDS);
+        return array();
+    }
+
     $people = get_posts(array(
         'post_type' => 'persona_pubblica',
         'post_status' => 'publish',
-        'numberposts' => -1,
+        'posts_per_page' => -1,
         'orderby' => 'title',
         'order' => 'ASC',
     ));
@@ -834,24 +869,43 @@ function dci_get_amministrazione_politica(WP_REST_Request $request) {
     $response = array();
 
     foreach ($people as $person) {
-        $incarichi_ids = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person->ID));
-        if (empty($incarichi_ids)) {
+        $data_conclusione_persona = dci_get_meta('data_conclusione_incarico', '_dci_persona_pubblica_', $person->ID);
+        if (!empty($data_conclusione_persona)) {
+            $data_conclusione_persona_ts = is_numeric($data_conclusione_persona) ? intval($data_conclusione_persona) : strtotime($data_conclusione_persona);
+            if ($data_conclusione_persona_ts && $data_conclusione_persona_ts < $today_ts) {
+                continue;
+            }
+        }
+
+        $incarichi_persona = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person->ID));
+        if (empty($incarichi_persona)) {
             continue;
         }
 
         $ruoli = array();
-        foreach ($incarichi_ids as $incarico_id) {
-            $incarico = get_post($incarico_id);
-            if ($incarico instanceof WP_Post && $incarico->post_status === 'publish') {
-                $ruoli[] = $incarico->post_title;
+        foreach ($incarichi_persona as $incarico_id) {
+            if (isset($incarichi_politici_attivi[$incarico_id])) {
+                $ruoli[] = $incarichi_politici_attivi[$incarico_id];
             }
         }
 
+        $ruoli = array_values(array_unique($ruoli));
         if (empty($ruoli)) {
             continue;
         }
 
         $thumbnail_id = get_post_thumbnail_id($person->ID);
+        $immagine_url = $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null;
+
+        if (empty($immagine_url)) {
+            $foto_meta = dci_get_meta('foto', '_dci_persona_pubblica_', $person->ID);
+            if (is_string($foto_meta) && filter_var($foto_meta, FILTER_VALIDATE_URL)) {
+                $immagine_url = $foto_meta;
+            } elseif (is_numeric($foto_meta)) {
+                $immagine_url = wp_get_attachment_image_url((int) $foto_meta, 'full');
+            }
+        }
+
         $contatti = dci_get_contatti_da_punti_ids(
             dci_normalize_meta_ids(dci_get_meta('punti_contatto', '_dci_persona_pubblica_', $person->ID))
         );
@@ -860,9 +914,10 @@ function dci_get_amministrazione_politica(WP_REST_Request $request) {
             'id' => $person->ID,
             'nome' => get_the_title($person->ID),
             'url' => get_permalink($person->ID),
-            'ruoli' => array_values(array_unique($ruoli)),
+            'ruoli' => $ruoli,
             'descrizione_breve' => dci_get_meta('descrizione_breve', '_dci_persona_pubblica_', $person->ID),
-            'immagine' => $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null,
+            'immagine' => $immagine_url,
+            'url_foto' => $immagine_url,
             'contatti' => $contatti,
         );
     }


### PR DESCRIPTION
### Motivation
- Ensure the `dci_get_amministrazione_politica` REST response includes only currently active political assignments and excludes ended assignments and people.
- Reduce unnecessary post lookups and improve performance by building an active-assignments map and bumping the cache version.
- Provide a more robust image field by falling back to the `foto` meta when no featured image is present.

### Description
- Bumped the cache key to `dci_api_amministrazione_politica_v5` to reflect behavior changes and avoid stale results.
- Added a query for `post_type => 'incarico'` scoped to the `tipi_incarico` term `politico`, and built an `$incarichi_politici_attivi` map that filters out assignments whose `data_conclusione_incarico` is in the past.
- Changed people query to use `posts_per_page => -1` and skip persons whose own `data_conclusione_incarico` has passed, then filter each person's `incarichi` to only include active assignments from the map.
- Improved image handling by resolving the featured image first, then falling back to the `foto` meta when it is either a URL or an attachment ID, and added a `url_foto` field; ensured `ruoli` is unique and preserved ordering.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aecda39fc83329810cf2dc633f402)