### PR TITLE
Filter active political roles and improve image handling in `dci_get_amministrazione_politica`; validate `ufficio` term

### DIFF
--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -817,41 +817,116 @@ function dci_normalize_meta_ids($value) {
  * @return array[]
  */
 function dci_get_amministrazione_politica(WP_REST_Request $request) {
-    $cache_key = 'dci_api_amministrazione_politica_v2';
+    $cache_key = 'dci_api_amministrazione_politica_v5';
     $cached = get_transient($cache_key);
     if (is_array($cached)) {
         return $cached;
     }
 
+    $incarichi_politici = get_posts(array(
+        'post_type' => 'incarico',
+        'post_status' => 'publish',
+        'posts_per_page' => -1,
+        'orderby' => 'title',
+        'order' => 'ASC',
+        'tax_query' => array(
+            array(
+                'taxonomy' => 'tipi_incarico',
+                'field' => 'slug',
+                'terms' => array('politico'),
+            ),
+        ),
+    ));
+
+    $today_ts = current_time('timestamp');
+    $incarichi_politici_attivi = array();
+    $persone_ids_da_incarichi_politici = array();
+
+    foreach ($incarichi_politici as $incarico) {
+        $persone_ids_incarico = dci_normalize_meta_ids(get_post_meta($incarico->ID, '_dci_incarico_persona'));
+        foreach ($persone_ids_incarico as $persona_id) {
+            $persone_ids_da_incarichi_politici[] = $persona_id;
+        }
+        $data_fine_incarico = dci_get_meta('data_conclusione_incarico', '_dci_incarico_', $incarico->ID);
+        if (!empty($data_fine_incarico)) {
+            $data_fine_ts = is_numeric($data_fine_incarico) ? intval($data_fine_incarico) : strtotime($data_fine_incarico);
+            if ($data_fine_ts && $data_fine_ts < $today_ts) {
+                continue;
+            }
+        }
+
+        $incarichi_politici_attivi[$incarico->ID] = $incarico->post_title;
+    }
+
+    $persone_ids_da_incarichi_politici = array_values(array_unique($persone_ids_da_incarichi_politici));
+
+    if (empty($incarichi_politici_attivi) || empty($persone_ids_da_incarichi_politici)) {
+        set_transient($cache_key, array(), 5 * MINUTE_IN_SECONDS);
+        return array();
+    }
+
     $people = get_posts(array(
         'post_type' => 'persona_pubblica',
         'post_status' => 'publish',
-        'numberposts' => -1,
+        'posts_per_page' => -1,
         'orderby' => 'title',
         'order' => 'ASC',
+        'post__in' => $persone_ids_da_incarichi_politici,
     ));
 
     $response = array();
 
     foreach ($people as $person) {
-        $incarichi_ids = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person->ID));
-        if (empty($incarichi_ids)) {
+        $data_conclusione_persona = dci_get_meta('data_conclusione_incarico', '_dci_persona_pubblica_', $person->ID);
+        if (!empty($data_conclusione_persona)) {
+            $data_conclusione_persona_ts = is_numeric($data_conclusione_persona) ? intval($data_conclusione_persona) : strtotime($data_conclusione_persona);
+            if ($data_conclusione_persona_ts && $data_conclusione_persona_ts < $today_ts) {
+                continue;
+            }
+        }
+
+        $incarichi_persona = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person->ID));
+        if (empty($incarichi_persona)) {
             continue;
         }
 
         $ruoli = array();
-        foreach ($incarichi_ids as $incarico_id) {
-            $incarico = get_post($incarico_id);
-            if ($incarico instanceof WP_Post && $incarico->post_status === 'publish') {
-                $ruoli[] = $incarico->post_title;
+        foreach ($incarichi_persona as $incarico_id) {
+            if (isset($incarichi_politici_attivi[$incarico_id])) {
+                $ruoli[] = $incarichi_politici_attivi[$incarico_id];
             }
         }
 
+        $ruoli = array_values(array_unique($ruoli));
         if (empty($ruoli)) {
             continue;
         }
 
         $thumbnail_id = get_post_thumbnail_id($person->ID);
+        $immagine = $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null;
+
+        if (empty($immagine)) {
+            $foto_meta = dci_get_meta('foto', '_dci_persona_pubblica_', $person->ID);
+            if (is_string($foto_meta) && filter_var($foto_meta, FILTER_VALIDATE_URL)) {
+                $immagine = $foto_meta;
+            } elseif (is_numeric($foto_meta)) {
+                $immagine = wp_get_attachment_image_url((int) $foto_meta, 'full');
+            } elseif (is_array($foto_meta)) {
+                foreach ($foto_meta as $foto_value) {
+                    if (is_string($foto_value) && filter_var($foto_value, FILTER_VALIDATE_URL)) {
+                        $immagine = $foto_value;
+                        break;
+                    }
+                    if (is_numeric($foto_value)) {
+                        $immagine = wp_get_attachment_image_url((int) $foto_value, 'full');
+                        if (!empty($immagine)) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
         $contatti = dci_get_contatti_da_punti_ids(
             dci_normalize_meta_ids(dci_get_meta('punti_contatto', '_dci_persona_pubblica_', $person->ID))
         );
@@ -860,9 +935,10 @@ function dci_get_amministrazione_politica(WP_REST_Request $request) {
             'id' => $person->ID,
             'nome' => get_the_title($person->ID),
             'url' => get_permalink($person->ID),
-            'ruoli' => array_values(array_unique($ruoli)),
+            'ruoli' => $ruoli,
             'descrizione_breve' => dci_get_meta('descrizione_breve', '_dci_persona_pubblica_', $person->ID),
-            'immagine' => $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null,
+            'immagine' => $immagine,
+            'url_foto' => $immagine,
             'contatti' => $contatti,
         );
     }
@@ -903,6 +979,11 @@ function dci_get_uffici_responsabili(WP_REST_Request $request) {
     $response = array();
 
     foreach ($uffici as $ufficio) {
+        $tipi_ufficio = get_the_terms($ufficio, 'tipi_unita_organizzativa');
+        if (!is_array($tipi_ufficio) || empty($tipi_ufficio) || !isset($tipi_ufficio[0]->slug) || $tipi_ufficio[0]->slug !== 'ufficio') {
+            continue;
+        }
+
         $responsabili_ids = dci_normalize_meta_ids(dci_get_meta('responsabile', '_dci_unita_organizzativa_', $ufficio->ID));
         $responsabili = array();
 


### PR DESCRIPTION
### Motivation
- Ensure the `dci_get_amministrazione_politica` endpoint returns only currently active political roles and associated people and to improve robustness of returned images and caching.
- Avoid returning people/offices whose roles have concluded and ensure `unita_organizzativa` items are actually of type `ufficio`.

### Description
- Bumped the cache key from `dci_api_amministrazione_politica_v2` to `dci_api_amministrazione_politica_v5` and added an early-return cached-path.
- Prefetches `incarico` posts with taxonomy `tipi_incarico:politico`, filters out expired incarichi by `data_conclusione_incarico`, and collects associated person IDs to restrict the `persona_pubblica` query via `post__in` and `posts_per_page`.
- Skips `persona_pubblica` posts whose personal `data_conclusione_incarico` is in the past, computes roles only from active political incarichi, and deduplicates roles.
- Improves image resolution and fallback: prefer featured image, then handle `foto` meta as URL, attachment ID, or array of values and expose the result in both `immagine` and `url_foto` fields.
- In `dci_get_uffici_responsabili` adds a check to ensure the unit has `tipi_unita_organizzativa` with slug `ufficio` before processing, and normalizes some `get_posts` params (uses `posts_per_page`).

### Testing
- No automated tests were added for this change and no automated test suite was run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aecda39fc83329810cf2dc633f402)