### PR TITLE
Add `descrizione_completa` to REST payloads for evento and luogo

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -838,6 +838,13 @@ add_action('rest_api_init', function () {
         }
     ]);
 
+    register_rest_field('evento', 'descrizione_completa', [
+        'get_callback' => function ($post) {
+            $payload = dci_get_evento_rest_payload($post['id']);
+            return $payload['descrizione_completa'];
+        }
+    ]);
+
     register_rest_field('evento', 'immagine', [
         'get_callback' => function ($post) {
             $payload = dci_get_evento_rest_payload($post['id']);
@@ -915,6 +922,7 @@ add_action('rest_api_init', function () {
             $data = [
                 'immagine' => $all_meta[$prefix . 'immagine'][0] ?? '',
                 'descrizione' => $all_meta[$prefix . 'descrizione_breve'][0] ?? '',
+                'descrizione_completa' => $all_meta[$prefix . 'descrizione_estesa'][0] ?? '',
                 'lat' => $gps['lat'] ?? '',
                 'lng' => $gps['lng'] ?? '',
                 'indirizzo' => $all_meta[$prefix . 'indirizzo'][0] ?? '',
@@ -1140,6 +1148,7 @@ if (!function_exists('dci_get_evento_rest_payload')) {
                 'data_inizio' => '',
                 'data_fine' => '',
                 'descrizione_breve' => '',
+                'descrizione_completa' => '',
                 'immagine' => null,
             );
         }
@@ -1185,6 +1194,7 @@ if (!function_exists('dci_get_evento_rest_payload')) {
             'data_inizio' => $meta['_dci_evento_data_orario_inizio'][0] ?? '',
             'data_fine' => $meta['_dci_evento_data_orario_fine'][0] ?? '',
             'descrizione_breve' => $meta['_dci_evento_descrizione_breve'][0] ?? '',
+            'descrizione_completa' => $meta['_dci_evento_descrizione_completa'][0] ?? '',
             'immagine' => $immagine,
         );
 


### PR DESCRIPTION
### Motivation

- Ensure the REST API returns the full/extended description for events and places so consumers can display complete content without additional queries.
- Keep the optimized, cached payloads consistent with the existing `descrizione_breve` and `immagine` fields.

### Description

- Added a new REST field registration for `evento` named `descrizione_completa` via `register_rest_field` that sources data from `dci_get_evento_rest_payload`.
- Extended the `dci_get_evento_rest_payload` function to include a default `descrizione_completa` and to populate it from the meta key `_dci_evento_descrizione_completa` when building the cached payload.
- Added `descrizione_completa` to the `luogo` payload, populated from the meta key `_dci_luogo_descrizione_estesa` and saved into the `luogo_meta_` transient cache.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0fe265348332a233ecf56d15ed2b)