### PR TITLE
Add full description fields to REST payloads and tighten administration filtering

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -838,6 +838,13 @@ add_action('rest_api_init', function () {
         }
     ]);
 
+    register_rest_field('evento', 'descrizione_completa', [
+        'get_callback' => function ($post) {
+            $payload = dci_get_evento_rest_payload($post['id']);
+            return $payload['descrizione_completa'];
+        }
+    ]);
+
     register_rest_field('evento', 'immagine', [
         'get_callback' => function ($post) {
             $payload = dci_get_evento_rest_payload($post['id']);
@@ -915,6 +922,7 @@ add_action('rest_api_init', function () {
             $data = [
                 'immagine' => $all_meta[$prefix . 'immagine'][0] ?? '',
                 'descrizione' => $all_meta[$prefix . 'descrizione_breve'][0] ?? '',
+                'descrizione_completa' => $all_meta[$prefix . 'descrizione_estesa'][0] ?? '',
                 'lat' => $gps['lat'] ?? '',
                 'lng' => $gps['lng'] ?? '',
                 'indirizzo' => $all_meta[$prefix . 'indirizzo'][0] ?? '',
@@ -1140,6 +1148,7 @@ if (!function_exists('dci_get_evento_rest_payload')) {
                 'data_inizio' => '',
                 'data_fine' => '',
                 'descrizione_breve' => '',
+                'descrizione_completa' => '',
                 'immagine' => null,
             );
         }
@@ -1185,6 +1194,7 @@ if (!function_exists('dci_get_evento_rest_payload')) {
             'data_inizio' => $meta['_dci_evento_data_orario_inizio'][0] ?? '',
             'data_fine' => $meta['_dci_evento_data_orario_fine'][0] ?? '',
             'descrizione_breve' => $meta['_dci_evento_descrizione_breve'][0] ?? '',
+            'descrizione_completa' => $meta['_dci_evento_descrizione_completa'][0] ?? '',
             'immagine' => $immagine,
         );
 

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -817,55 +817,130 @@ function dci_normalize_meta_ids($value) {
  * @return array[]
  */
 function dci_get_amministrazione_politica(WP_REST_Request $request) {
-    $cache_key = 'dci_api_amministrazione_politica_v2';
+    $cache_key = 'dci_api_amministrazione_politica_v3';
     $cached = get_transient($cache_key);
     if (is_array($cached)) {
         return $cached;
     }
 
-    $people = get_posts(array(
-        'post_type' => 'persona_pubblica',
+    $today_ts = current_time('timestamp');
+
+    $candidate_person_ids = array();
+
+    // Persone collegate a incarichi politici.
+    $incarichi_politici = get_posts(array(
+        'post_type' => 'incarico',
         'post_status' => 'publish',
         'numberposts' => -1,
-        'orderby' => 'title',
-        'order' => 'ASC',
+        'fields' => 'ids',
+        'tax_query' => array(
+            array(
+                'taxonomy' => 'tipi_incarico',
+                'field' => 'slug',
+                'terms' => array('politico'),
+            ),
+        ),
     ));
+
+    foreach ($incarichi_politici as $incarico_id) {
+        $persone_incarico = dci_normalize_meta_ids(get_post_meta($incarico_id, '_dci_incarico_persona', false));
+        foreach ($persone_incarico as $persona_id) {
+            $candidate_person_ids[$persona_id] = true;
+        }
+    }
+
+    // Persone collegate alle unità organizzative politiche richieste.
+    $uo_politiche = get_posts(array(
+        'post_type' => 'unita_organizzativa',
+        'post_status' => 'publish',
+        'numberposts' => -1,
+        'fields' => 'ids',
+        'post_name__in' => array('sindaco', 'giunta-comunale', 'consiglio-comunale'),
+    ));
+
+    foreach ($uo_politiche as $uo_id) {
+        $responsabili = dci_normalize_meta_ids(dci_get_meta('responsabile', '_dci_unita_organizzativa_', $uo_id));
+        $persone_struttura = dci_normalize_meta_ids(dci_get_meta('persone_struttura', '_dci_unita_organizzativa_', $uo_id));
+
+        foreach (array_merge($responsabili, $persone_struttura) as $persona_id) {
+            $candidate_person_ids[$persona_id] = true;
+        }
+    }
+
+    if (empty($candidate_person_ids)) {
+        set_transient($cache_key, array(), 5 * MINUTE_IN_SECONDS);
+        return array();
+    }
 
     $response = array();
 
-    foreach ($people as $person) {
-        $incarichi_ids = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person->ID));
-        if (empty($incarichi_ids)) {
+    foreach (array_keys($candidate_person_ids) as $person_id) {
+        $person = get_post($person_id);
+        if (!$person instanceof WP_Post || $person->post_type !== 'persona_pubblica' || $person->post_status !== 'publish') {
             continue;
         }
 
-        $ruoli = array();
-        foreach ($incarichi_ids as $incarico_id) {
-            $incarico = get_post($incarico_id);
-            if ($incarico instanceof WP_Post && $incarico->post_status === 'publish') {
-                $ruoli[] = $incarico->post_title;
+        $data_conclusione_persona = dci_get_meta('data_conclusione_incarico', '_dci_persona_pubblica_', $person_id);
+        if (!empty($data_conclusione_persona)) {
+            $fine_persona_ts = is_numeric($data_conclusione_persona) ? intval($data_conclusione_persona) : strtotime($data_conclusione_persona);
+            if ($fine_persona_ts && $fine_persona_ts < $today_ts) {
+                continue;
             }
         }
 
-        if (empty($ruoli)) {
+        $incarichi_ids = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person_id));
+        $ruoli = array();
+        $has_active_role = false;
+
+        foreach ($incarichi_ids as $incarico_id) {
+            $incarico = get_post($incarico_id);
+            if (!$incarico instanceof WP_Post || $incarico->post_status !== 'publish') {
+                continue;
+            }
+
+            $ruoli[] = $incarico->post_title;
+
+            $fine_incarico = dci_get_meta('data_conclusione_incarico', '_dci_incarico_', $incarico_id);
+            if (empty($fine_incarico)) {
+                $has_active_role = true;
+                continue;
+            }
+
+            $fine_incarico_ts = is_numeric($fine_incarico) ? intval($fine_incarico) : strtotime($fine_incarico);
+            if (!$fine_incarico_ts || $fine_incarico_ts >= $today_ts) {
+                $has_active_role = true;
+            }
+        }
+
+        if (empty($ruoli) || !$has_active_role) {
             continue;
         }
 
-        $thumbnail_id = get_post_thumbnail_id($person->ID);
+        $thumbnail_id = get_post_thumbnail_id($person_id);
+        $foto_persona = dci_get_meta('foto', '_dci_persona_pubblica_', $person_id);
+        $immagine = $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null;
+        if (empty($immagine) && !empty($foto_persona)) {
+            $immagine = is_string($foto_persona) ? $foto_persona : null;
+        }
+
         $contatti = dci_get_contatti_da_punti_ids(
-            dci_normalize_meta_ids(dci_get_meta('punti_contatto', '_dci_persona_pubblica_', $person->ID))
+            dci_normalize_meta_ids(dci_get_meta('punti_contatto', '_dci_persona_pubblica_', $person_id))
         );
 
         $response[] = array(
-            'id' => $person->ID,
-            'nome' => get_the_title($person->ID),
-            'url' => get_permalink($person->ID),
+            'id' => $person_id,
+            'nome' => get_the_title($person_id),
+            'url' => get_permalink($person_id),
             'ruoli' => array_values(array_unique($ruoli)),
-            'descrizione_breve' => dci_get_meta('descrizione_breve', '_dci_persona_pubblica_', $person->ID),
-            'immagine' => $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null,
+            'descrizione_breve' => dci_get_meta('descrizione_breve', '_dci_persona_pubblica_', $person_id),
+            'immagine' => $immagine,
             'contatti' => $contatti,
         );
     }
+
+    usort($response, function ($a, $b) {
+        return strcasecmp((string) $a['nome'], (string) $b['nome']);
+    });
 
     set_transient($cache_key, $response, 5 * MINUTE_IN_SECONDS);
 


### PR DESCRIPTION
### Motivation
- Expose complete descriptions for content types in the REST API payloads to support clients that need the full text.
- Improve the `dci_get_amministrazione_politica` endpoint to reliably return currently active political office-holders and avoid stale/irrelevant entries.

### Description
- Added a `descrizione_completa` REST field for `evento` and included `descrizione_completa` in the `dci_get_evento_rest_payload` output.
- Added `descrizione_completa` to `luogo` payloads sourced from `_dci_luogo_descrizione_estesa` meta.
- Reworked `dci_get_amministrazione_politica` to use a new cache key `dci_api_amministrazione_politica_v3` and to build a candidate person set from published `incarico` posts (taxonomy filter `tipi_incarico:politico`) and specific `unita_organizzativa` slugs (`sindaco`, `giunta-comunale`, `consiglio-comunale`).
- Added filtering of people and incarichi by `data_conclusione_incarico` to exclude expired roles, normalized meta handling, image fallback to `foto` meta when no featured image exists, updated contact lookup to use person IDs, and sorted the resulting list by name.

### Testing
- No new automated unit tests were added for this change.
- Performed PHP syntax checks with `php -l` on the modified files which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0fe265348332a233ecf56d15ed2b)