### PR TITLE
Include complete descriptions in REST payloads and refine amministrazione_politica selection and ordering

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -838,6 +838,13 @@ add_action('rest_api_init', function () {
         }
     ]);
 
+    register_rest_field('evento', 'descrizione_completa', [
+        'get_callback' => function ($post) {
+            $payload = dci_get_evento_rest_payload($post['id']);
+            return $payload['descrizione_completa'];
+        }
+    ]);
+
     register_rest_field('evento', 'immagine', [
         'get_callback' => function ($post) {
             $payload = dci_get_evento_rest_payload($post['id']);
@@ -915,6 +922,7 @@ add_action('rest_api_init', function () {
             $data = [
                 'immagine' => $all_meta[$prefix . 'immagine'][0] ?? '',
                 'descrizione' => $all_meta[$prefix . 'descrizione_breve'][0] ?? '',
+                'descrizione_completa' => $all_meta[$prefix . 'descrizione_estesa'][0] ?? '',
                 'lat' => $gps['lat'] ?? '',
                 'lng' => $gps['lng'] ?? '',
                 'indirizzo' => $all_meta[$prefix . 'indirizzo'][0] ?? '',
@@ -1140,6 +1148,7 @@ if (!function_exists('dci_get_evento_rest_payload')) {
                 'data_inizio' => '',
                 'data_fine' => '',
                 'descrizione_breve' => '',
+                'descrizione_completa' => '',
                 'immagine' => null,
             );
         }
@@ -1185,6 +1194,7 @@ if (!function_exists('dci_get_evento_rest_payload')) {
             'data_inizio' => $meta['_dci_evento_data_orario_inizio'][0] ?? '',
             'data_fine' => $meta['_dci_evento_data_orario_fine'][0] ?? '',
             'descrizione_breve' => $meta['_dci_evento_descrizione_breve'][0] ?? '',
+            'descrizione_completa' => $meta['_dci_evento_descrizione_completa'][0] ?? '',
             'immagine' => $immagine,
         );
 

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -817,55 +817,198 @@ function dci_normalize_meta_ids($value) {
  * @return array[]
  */
 function dci_get_amministrazione_politica(WP_REST_Request $request) {
-    $cache_key = 'dci_api_amministrazione_politica_v2';
+    $cache_key = 'dci_api_amministrazione_politica_v3';
     $cached = get_transient($cache_key);
     if (is_array($cached)) {
         return $cached;
     }
 
-    $people = get_posts(array(
-        'post_type' => 'persona_pubblica',
+    $today_ts = current_time('timestamp');
+
+    $candidate_person_ids = array();
+
+    // Persone collegate a incarichi politici.
+    $incarichi_politici = get_posts(array(
+        'post_type' => 'incarico',
         'post_status' => 'publish',
         'numberposts' => -1,
-        'orderby' => 'title',
-        'order' => 'ASC',
+        'fields' => 'ids',
+        'tax_query' => array(
+            array(
+                'taxonomy' => 'tipi_incarico',
+                'field' => 'slug',
+                'terms' => array('politico'),
+            ),
+        ),
     ));
+
+    foreach ($incarichi_politici as $incarico_id) {
+        $persone_incarico = dci_normalize_meta_ids(get_post_meta($incarico_id, '_dci_incarico_persona', false));
+        foreach ($persone_incarico as $persona_id) {
+            $candidate_person_ids[$persona_id] = true;
+        }
+    }
+
+    // Persone collegate alle unità organizzative politiche richieste.
+    $uo_politiche = get_posts(array(
+        'post_type' => 'unita_organizzativa',
+        'post_status' => 'publish',
+        'numberposts' => -1,
+        'fields' => 'ids',
+        'post_name__in' => array('sindaco', 'giunta-comunale', 'consiglio-comunale'),
+    ));
+
+    foreach ($uo_politiche as $uo_id) {
+        $responsabili = dci_normalize_meta_ids(dci_get_meta('responsabile', '_dci_unita_organizzativa_', $uo_id));
+        $persone_struttura = dci_normalize_meta_ids(dci_get_meta('persone_struttura', '_dci_unita_organizzativa_', $uo_id));
+
+        foreach (array_merge($responsabili, $persone_struttura) as $persona_id) {
+            $candidate_person_ids[$persona_id] = true;
+        }
+    }
+
+    if (empty($candidate_person_ids)) {
+        set_transient($cache_key, array(), 5 * MINUTE_IN_SECONDS);
+        return array();
+    }
 
     $response = array();
 
-    foreach ($people as $person) {
-        $incarichi_ids = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person->ID));
-        if (empty($incarichi_ids)) {
+
+    $role_rank = function ($role_title) {
+        $normalized = sanitize_title((string) $role_title);
+
+        $priority_map = array(
+            'sindaco' => 0,
+            'vicesindaco' => 1,
+            'vice-sindaco' => 1,
+            'assessore' => 2,
+            'giunta-comunale' => 2,
+            'presidente-del-consiglio' => 3,
+            'vicepresidente-del-consiglio' => 4,
+            'consigliere' => 5,
+            'consigliere-comunale' => 5,
+        );
+
+        if (isset($priority_map[$normalized])) {
+            return $priority_map[$normalized];
+        }
+
+        if (strpos($normalized, 'sindaco') !== false) {
+            return 0;
+        }
+        if (strpos($normalized, 'vice') !== false && strpos($normalized, 'sindaco') !== false) {
+            return 1;
+        }
+        if (strpos($normalized, 'assessore') !== false || strpos($normalized, 'giunta') !== false) {
+            return 2;
+        }
+        if (strpos($normalized, 'presidente-del-consiglio') !== false) {
+            return 3;
+        }
+        if (strpos($normalized, 'vicepresidente-del-consiglio') !== false) {
+            return 4;
+        }
+        if (strpos($normalized, 'consigliere') !== false) {
+            return 5;
+        }
+
+        return 99;
+    };
+
+    foreach (array_keys($candidate_person_ids) as $person_id) {
+        $person = get_post($person_id);
+        if (!$person instanceof WP_Post || $person->post_type !== 'persona_pubblica' || $person->post_status !== 'publish') {
             continue;
         }
 
-        $ruoli = array();
-        foreach ($incarichi_ids as $incarico_id) {
-            $incarico = get_post($incarico_id);
-            if ($incarico instanceof WP_Post && $incarico->post_status === 'publish') {
-                $ruoli[] = $incarico->post_title;
+        $data_conclusione_persona = dci_get_meta('data_conclusione_incarico', '_dci_persona_pubblica_', $person_id);
+        if (!empty($data_conclusione_persona)) {
+            $fine_persona_ts = is_numeric($data_conclusione_persona) ? intval($data_conclusione_persona) : strtotime($data_conclusione_persona);
+            if ($fine_persona_ts && $fine_persona_ts < $today_ts) {
+                continue;
             }
         }
 
-        if (empty($ruoli)) {
+        $incarichi_ids = dci_normalize_meta_ids(dci_get_meta('incarichi', '_dci_persona_pubblica_', $person_id));
+        $ruoli = array();
+        $has_active_role = false;
+
+        foreach ($incarichi_ids as $incarico_id) {
+            $incarico = get_post($incarico_id);
+            if (!$incarico instanceof WP_Post || $incarico->post_status !== 'publish') {
+                continue;
+            }
+
+            $ruoli[] = $incarico->post_title;
+
+            $fine_incarico = dci_get_meta('data_conclusione_incarico', '_dci_incarico_', $incarico_id);
+            if (empty($fine_incarico)) {
+                $has_active_role = true;
+                continue;
+            }
+
+            $fine_incarico_ts = is_numeric($fine_incarico) ? intval($fine_incarico) : strtotime($fine_incarico);
+            if (!$fine_incarico_ts || $fine_incarico_ts >= $today_ts) {
+                $has_active_role = true;
+            }
+        }
+
+        if (empty($ruoli) || !$has_active_role) {
             continue;
         }
 
-        $thumbnail_id = get_post_thumbnail_id($person->ID);
+        $thumbnail_id = get_post_thumbnail_id($person_id);
+        $foto_persona = dci_get_meta('foto', '_dci_persona_pubblica_', $person_id);
+        $immagine = $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null;
+
+        if (empty($immagine) && !empty($foto_persona)) {
+            if (is_numeric($foto_persona)) {
+                $img_url = wp_get_attachment_image_url((int) $foto_persona, 'full');
+                $immagine = $img_url ? $img_url : null;
+            } elseif (is_array($foto_persona) && isset($foto_persona['url']) && is_string($foto_persona['url'])) {
+                $immagine = $foto_persona['url'];
+            } elseif (is_string($foto_persona)) {
+                $immagine = $foto_persona;
+            }
+        }
+
         $contatti = dci_get_contatti_da_punti_ids(
-            dci_normalize_meta_ids(dci_get_meta('punti_contatto', '_dci_persona_pubblica_', $person->ID))
+            dci_normalize_meta_ids(dci_get_meta('punti_contatto', '_dci_persona_pubblica_', $person_id))
         );
 
+        $ruoli_unici = array_values(array_unique($ruoli));
+        usort($ruoli_unici, function ($a, $b) use ($role_rank) {
+            $rank_cmp = $role_rank($a) <=> $role_rank($b);
+            if ($rank_cmp !== 0) {
+                return $rank_cmp;
+            }
+
+            return strcasecmp((string) $a, (string) $b);
+        });
+
         $response[] = array(
-            'id' => $person->ID,
-            'nome' => get_the_title($person->ID),
-            'url' => get_permalink($person->ID),
-            'ruoli' => array_values(array_unique($ruoli)),
-            'descrizione_breve' => dci_get_meta('descrizione_breve', '_dci_persona_pubblica_', $person->ID),
-            'immagine' => $thumbnail_id ? wp_get_attachment_image_url($thumbnail_id, 'full') : null,
+            'id' => $person_id,
+            'nome' => get_the_title($person_id),
+            'url' => get_permalink($person_id),
+            'ruoli' => $ruoli_unici,
+            'descrizione_breve' => dci_get_meta('descrizione_breve', '_dci_persona_pubblica_', $person_id),
+            'immagine' => $immagine,
             'contatti' => $contatti,
         );
     }
+
+    usort($response, function ($a, $b) use ($role_rank) {
+        $a_primary = isset($a['ruoli'][0]) ? $role_rank($a['ruoli'][0]) : 99;
+        $b_primary = isset($b['ruoli'][0]) ? $role_rank($b['ruoli'][0]) : 99;
+
+        $rank_cmp = $a_primary <=> $b_primary;
+        if ($rank_cmp !== 0) {
+            return $rank_cmp;
+        }
+
+        return strcasecmp((string) $a['nome'], (string) $b['nome']);
+    });
 
     set_transient($cache_key, $response, 5 * MINUTE_IN_SECONDS);
 


### PR DESCRIPTION
### Motivation
- Expose richer content in REST responses by returning full descriptions for events and places and make the political administration endpoint more accurate and ordered.
- Improve selection of public people to only include those with active political roles and to derive candidates from both `incarico` posts and specific organizational units.

### Description
- Added `descrizione_completa` REST field for `evento` and included `descrizione_completa` in the event payload returned by `dci_get_evento_rest_payload`.
- Included `descrizione_completa` for `luogo` meta payload using the `_dci_luogo_descrizione_estesa` meta key.
- Bumped cache key for `dci_get_amministrazione_politica` to `dci_api_amministrazione_politica_v3` and changed the selection logic to collect candidate person IDs from published `incarico` posts with `tipi_incarico:politico` and from specific `unita_organizzativa` slugs (`sindaco`, `giunta-comunale`, `consiglio-comunale`).
- Filtered out people and roles that have concluded by comparing `data_conclusione_incarico` / `data_conclusione_incarico` on person to the current time, and require at least one active role to include a person.
- Normalized and deduplicated roles, added robust image resolution (thumbnail, numeric ID, array with `url`, or string), and introduced a `role_rank` helper to sort roles and the final people list by priority.
- Minor refactors to use IDs consistently and to cache the response for 5 minutes via `set_transient`.

### Testing
- Ran a PHP syntax check (`php -l`) on modified files which reported no syntax errors.
- Exercised the affected REST endpoints in a local environment to verify `descrizione_completa` is returned for `evento` and `luogo` and that `dci_get_amministrazione_politica` returns filtered, ordered results; no regressions observed.
- Executed the project's PHPUnit suite where available and observed no failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0fe265348332a233ecf56d15ed2b)