### PR TITLE
Add lightweight frontend accessibility toolbar and image alt/title fallbacks

### DIFF
--- a/assets/css/accessibility-toolbar.css
+++ b/assets/css/accessibility-toolbar.css
@@ -1,0 +1,8 @@
+.dci-accessibility-toolbar{position:fixed;top:12px;left:12px;z-index:9999;display:flex;gap:8px;flex-wrap:wrap;background:#eef1f7;border-radius:8px;padding:8px;box-shadow:0 2px 8px rgba(0,0,0,.12)}
+.dci-a11y-btn{border:0;background:#dfe4ef;color:#14315f;padding:10px 12px;border-radius:6px;font-weight:700;cursor:pointer}
+.dci-a11y-btn.is-active{background:#0d3b79;color:#fff}
+.dci-a11y-btn-reset{background:#0d3b79;color:#fff}
+body.dci-a11y-links a{text-decoration:underline!important;text-decoration-thickness:2px!important}
+body.dci-a11y-cursor,* .dci-a11y-cursor{cursor:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M5 3l12 8l-5 1l3 7l-2 1l-3-7l-3 3z'/%3E%3C/svg%3E") 2 2,auto!important}
+body.dci-a11y-dyslexia{font-family:Verdana,Arial,sans-serif!important;letter-spacing:.02em;word-spacing:.06em;line-height:1.7}
+@media (max-width:991px){.dci-accessibility-toolbar{position:static;margin:8px auto;max-width:95%}}

--- a/assets/js/accessibility-toolbar.js
+++ b/assets/js/accessibility-toolbar.js
@@ -1,0 +1,47 @@
+(function(){
+  var KEY='dciA11yPrefs';
+  var root=document.documentElement;
+  var body=document.body;
+  if(!body)return;
+  var prefs={font:100,cursor:false,links:false,dyslexia:false};
+  try{var stored=JSON.parse(localStorage.getItem(KEY)||'{}');prefs=Object.assign(prefs,stored);}catch(e){}
+
+  function clamp(n,min,max){return Math.min(max,Math.max(min,n));}
+  function save(){localStorage.setItem(KEY,JSON.stringify(prefs));}
+  function apply(){
+    root.style.fontSize=prefs.font+'%';
+    body.classList.toggle('dci-a11y-cursor',!!prefs.cursor);
+    body.classList.toggle('dci-a11y-links',!!prefs.links);
+    body.classList.toggle('dci-a11y-dyslexia',!!prefs.dyslexia);
+    document.querySelectorAll('.dci-a11y-btn').forEach(function(btn){
+      var a=btn.getAttribute('data-a11y-action');
+      var active=(a==='cursor'&&prefs.cursor)||(a==='links'&&prefs.links)||(a==='dyslexia'&&prefs.dyslexia);
+      btn.classList.toggle('is-active',active);
+    });
+  }
+  function readContent(){
+    if(!('speechSynthesis' in window))return;
+    window.speechSynthesis.cancel();
+    var selected=(window.getSelection&&window.getSelection().toString())||'';
+    var txt=selected||((document.querySelector('main')||document.body).innerText||'').slice(0,3000);
+    if(!txt)return;
+    var u=new SpeechSynthesisUtterance(txt);
+    u.lang='it-IT';
+    window.speechSynthesis.speak(u);
+  }
+
+  document.addEventListener('click',function(e){
+    var btn=e.target.closest('.dci-a11y-btn'); if(!btn)return;
+    var a=btn.getAttribute('data-a11y-action');
+    if(a==='font-up')prefs.font=clamp(prefs.font+10,90,130);
+    if(a==='font-down')prefs.font=clamp(prefs.font-10,90,130);
+    if(a==='cursor')prefs.cursor=!prefs.cursor;
+    if(a==='links')prefs.links=!prefs.links;
+    if(a==='dyslexia')prefs.dyslexia=!prefs.dyslexia;
+    if(a==='read')readContent();
+    if(a==='reset'){prefs={font:100,cursor:false,links:false,dyslexia:false};window.speechSynthesis&&window.speechSynthesis.cancel();}
+    save();apply();
+  });
+
+  apply();
+})();

--- a/functions.php
+++ b/functions.php
@@ -171,6 +171,9 @@ function dci_scripts() {
 
     wp_enqueue_style( 'dci-font', get_template_directory_uri() . '/assets/css/fonts.css', array('dci-comuni'));
     wp_enqueue_style( 'dci-wp-style', get_template_directory_uri()."/style.css", array('dci-comuni'));
+    if ( ! is_404() ) {
+        wp_enqueue_style( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/css/accessibility-toolbar.css', array('dci-wp-style'), false );
+    }
 
 
     wp_enqueue_script( 'dci-modernizr', get_template_directory_uri() . '/assets/js/modernizr.custom.js');
@@ -195,6 +198,10 @@ function dci_scripts() {
         wp_enqueue_script( 'dci-boostrap-italia-min-js', get_template_directory_uri() . '/assets/js/bootstrap-italia.bundle.min.js', array(), false, true);
     }
 	wp_enqueue_script( 'dci-comuni', get_template_directory_uri() . '/assets/js/comuni.js', array(), false, true);
+	if ( ! is_404() ) {
+		wp_enqueue_script( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/js/accessibility-toolbar.js', array(), false, true);
+		wp_script_add_data( 'dci-accessibility-toolbar', 'defer', true );
+	}
 	wp_add_inline_script( 'dci-comuni', 'window.wpRestApi = "' . get_rest_url() . '"', 'before' );
 
 	wp_enqueue_script( 'dci-jquery-easing', get_template_directory_uri() . '/assets/js/components/jquery-easing/jquery.easing.js', array(), false, true);

--- a/header.php
+++ b/header.php
@@ -260,6 +260,7 @@ $current_group = dci_get_current_group();
 </header>
 
 <?php get_template_part("template-parts/common/search-modal"); ?>
+<?php get_template_part("template-parts/common/accessibility-toolbar"); ?>
 <?php
 if(!is_user_logged_in())
     get_template_part("template-parts/common/access-modal");

--- a/inc/filters.php
+++ b/inc/filters.php
@@ -36,3 +36,91 @@ function dci_vivere_il_comune_post_link( $post_link, $id = 0 ){
     return $post_link;
 }
 add_filter( 'post_type_link', 'dci_vivere_il_comune_post_link', 1, 3 );
+/**
+ * Build sanitized alt/title text for images based on related post title.
+ *
+ * Removes special characters, normalizes whitespace and limits length.
+ *
+ * @param int $post_id
+ * @return string
+ */
+function dci_get_sanitized_image_text_from_post( $post_id ) {
+    $max_length = 90;
+    $title = '';
+
+    if ( $post_id ) {
+        $title = get_the_title( $post_id );
+    }
+
+    if ( empty( $title ) && is_singular() ) {
+        $title = get_the_title();
+    }
+
+    if ( empty( $title ) ) {
+        return '';
+    }
+
+    $title = wp_strip_all_tags( $title );
+    $title = preg_replace( '/[^\p{L}\p{N}\s\-]/u', ' ', $title );
+    $title = preg_replace( '/\s+/u', ' ', $title );
+    $title = trim( $title );
+
+    if ( function_exists( 'mb_strlen' ) && function_exists( 'mb_substr' ) ) {
+        if ( mb_strlen( $title ) > $max_length ) {
+            $title = rtrim( mb_substr( $title, 0, $max_length - 1 ) ) . '…';
+        }
+    } elseif ( strlen( $title ) > $max_length ) {
+        $title = rtrim( substr( $title, 0, $max_length - 1 ) ) . '…';
+    }
+
+    return $title;
+}
+
+/**
+ * Ensure attachment images have meaningful alt and title attributes.
+ *
+ * @param array        $attr
+ * @param WP_Post      $attachment
+ * @param string|array $size
+ * @return array
+ */
+function dci_enforce_image_alt_and_title_attributes( $attr, $attachment, $size ) {
+    if ( is_admin() || wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+        return $attr;
+    }
+
+    // In produzione tocchiamo solo le immagini contenuto (featured), evitando asset tecnici/icons.
+    if ( empty( $attr['class'] ) || strpos( $attr['class'], 'wp-post-image' ) === false ) {
+        return $attr;
+    }
+
+    $related_post_id = get_the_ID();
+
+    if ( ! $related_post_id ) {
+        $queried_object_id = get_queried_object_id();
+        $related_post_id   = $queried_object_id ? $queried_object_id : 0;
+    }
+
+    if ( $related_post_id && get_post_thumbnail_id( $related_post_id ) !== (int) $attachment->ID ) {
+        $related_post_id = 0;
+    }
+
+    $fallback_text = dci_get_sanitized_image_text_from_post( $related_post_id );
+
+    if ( empty( $fallback_text ) ) {
+        $fallback_text = dci_get_sanitized_image_text_from_post( $attachment->post_parent );
+    }
+
+    if ( ! empty( $fallback_text ) ) {
+        if ( empty( $attr['alt'] ) ) {
+            $attr['alt'] = $fallback_text;
+        }
+
+        if ( empty( $attr['title'] ) ) {
+            $attr['title'] = ! empty( $attr['alt'] ) ? $attr['alt'] : $fallback_text;
+        }
+    }
+
+    return $attr;
+}
+add_filter( 'wp_get_attachment_image_attributes', 'dci_enforce_image_alt_and_title_attributes', 10, 3 );

--- a/template-parts/common/accessibility-toolbar.php
+++ b/template-parts/common/accessibility-toolbar.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Frontend accessibility toolbar (lightweight, no external plugin dependency).
+ */
+?>
+<div class="dci-accessibility-toolbar" role="region" aria-label="Strumenti di accessibilità">
+    <button type="button" class="dci-a11y-btn" data-a11y-action="font-up" aria-label="Aumenta dimensione testo">A+</button>
+    <button type="button" class="dci-a11y-btn" data-a11y-action="font-down" aria-label="Riduci dimensione testo">A-</button>
+    <button type="button" class="dci-a11y-btn" data-a11y-action="read" aria-label="Leggi il contenuto">Leggi</button>
+    <button type="button" class="dci-a11y-btn" data-a11y-action="cursor" aria-label="Attiva cursore grande">Cursore</button>
+    <button type="button" class="dci-a11y-btn" data-a11y-action="links" aria-label="Evidenzia link">Evidenzia Link</button>
+    <button type="button" class="dci-a11y-btn" data-a11y-action="dyslexia" aria-label="Modalità ad alta leggibilità">ADislessia</button>
+    <button type="button" class="dci-a11y-btn dci-a11y-btn-reset" data-a11y-action="reset" aria-label="Ripristina impostazioni">Reset</button>
+</div>


### PR DESCRIPTION
### Motivation
- Provide a small, dependency-free accessibility toolbar on the frontend to allow users to adjust font size, enable a large cursor, highlight links, switch to an easier-to-read font spacing, and trigger text-to-speech. 
- Improve image accessibility by ensuring meaningful `alt` and `title` attributes for post/featured images using post titles as fallbacks.

### Description
- Introduces a new accessibility toolbar template at `template-parts/common/accessibility-toolbar.php` with buttons for font size, read-aloud, cursor, link highlighting, dyslexia-friendly mode, and reset. 
- Adds frontend assets `assets/css/accessibility-toolbar.css` and `assets/js/accessibility-toolbar.js` implementing styles and client-side behavior, including persistence via `localStorage` and text-to-speech via `SpeechSynthesisUtterance`.
- Loads the toolbar markup in `header.php` by including the new template part and enqueues the CSS/JS in `functions.php` with conditional loading (skips 404 pages) and `defer` applied to the script. 
- Adds image accessibility helpers in `inc/filters.php`: `dci_get_sanitized_image_text_from_post()` to build sanitized fallback text and `dci_enforce_image_alt_and_title_attributes()` hooked to `wp_get_attachment_image_attributes` to populate missing `alt`/`title` for content images.

### Testing
- Ran PHP syntax checks with `php -l` on the modified PHP files and there were no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107f9e9db883329fdae06254799ee3)