### PR TITLE
Add front-end accessibility toolbar and image alt/title fallback

### DIFF
--- a/assets/css/accessibility-toolbar.css
+++ b/assets/css/accessibility-toolbar.css
@@ -1,0 +1,18 @@
+.dci-a11y{position:fixed;left:12px;bottom:12px;z-index:9998;font-family:Inter,Arial,sans-serif}
+.dci-a11y-toggle{border:0;background:linear-gradient(135deg,#0d3b79,#1f5daa);color:#fff;border-radius:999px;padding:10px 16px;font-weight:700;box-shadow:0 6px 20px rgba(13,59,121,.3)}
+.dci-a11y-panel{margin-top:10px;background:#f7f9fc;border:1px solid #dbe3ef;border-radius:12px;padding:10px;display:grid;grid-template-columns:repeat(2,minmax(150px,1fr));gap:8px;max-width:390px;max-height:62vh;overflow:auto;box-shadow:0 10px 26px rgba(10,32,66,.18)}
+.dci-a11y-btn{border:1px solid #cbd6e5;background:#fff;color:#1d2c3f;padding:10px;border-radius:10px;font-weight:600;min-height:56px;display:flex;align-items:center;gap:8px;text-align:left;line-height:1.2}
+.dci-a11y-ico{font-size:16px;display:inline-flex;width:18px;justify-content:center}
+.dci-a11y-btn:hover{background:#eef4ff}
+.dci-a11y-btn.is-active{background:#0d3b79;color:#fff;border-color:#0d3b79}
+.dci-a11y-btn-reset{background:#fff7f7;border-color:#f1c7c7}
+body.dci-a11y-links a{text-decoration:underline!important;text-decoration-thickness:2px!important}
+body.dci-a11y-dyslexia{font-family:Verdana,Arial,sans-serif!important;letter-spacing:.02em;word-spacing:.06em;line-height:1.7}
+body.dci-a11y-readable-font{font-family:Arial,Helvetica,sans-serif!important}
+body.dci-a11y-highlight-all p,body.dci-a11y-highlight-all li,body.dci-a11y-highlight-all span{background:#fff4a3!important}
+body.dci-a11y-highlight-titles h1,body.dci-a11y-highlight-titles h2,body.dci-a11y-highlight-titles h3,body.dci-a11y-highlight-titles h4{background:#fff4a3!important}
+body.dci-a11y-hide-images img{visibility:hidden!important}
+body.dci-a11y-stop-animations *,body.dci-a11y-stop-animations *::before,body.dci-a11y-stop-animations *::after{animation:none!important;transition:none!important}
+body.dci-a11y-keyboard *:focus{outline:3px solid #0d3b79!important;outline-offset:2px!important}
+[data-dci-a11y-target='1']{filter:var(--dci-a11y-filter,none)}
+@media (max-width:767px){.dci-a11y{left:8px;right:8px;bottom:8px}.dci-a11y-toggle{width:100%}.dci-a11y-panel{max-width:none;grid-template-columns:1fr 1fr;max-height:55vh}}

--- a/assets/js/accessibility-toolbar.js
+++ b/assets/js/accessibility-toolbar.js
@@ -1,0 +1,63 @@
+(function(){
+  var wrap=document.querySelector('[data-dci-a11y]'); if(!wrap) return;
+  var KEY='dciA11yPrefs',root=document.documentElement,body=document.body;
+  var panel=wrap.querySelector('#dci-a11y-panel'),toggle=wrap.querySelector('[data-a11y-action="toggle"]');
+  var target=document.querySelector('main')||document.getElementById('main')||body;
+  target.setAttribute('data-dci-a11y-target','1');
+  var levels={brightness:[100,115,130],contrast:[100,115,130],saturation:[100,80,120],grayscale:[0,100],lineHeight:[1.5,1.8,2.1],letterSpacing:[0,0.04,0.08]};
+  var prefs={font:100,cursor:false,links:false,dyslexia:false,invert:false,brightness:0,contrast:0,saturation:0,grayscale:0,readableFont:false,highlightAll:false,highlightTitles:false,hideImages:false,mute:false,stopAnimations:false,keyboard:false,lineHeight:0,letterSpacing:0};
+  try{prefs=Object.assign(prefs,JSON.parse(localStorage.getItem(KEY)||'{}'));}catch(e){}
+  function clamp(n,min,max){return Math.min(max,Math.max(min,n));}
+  function cycle(name){prefs[name]=(prefs[name]+1)%levels[name].length;}
+  function save(){localStorage.setItem(KEY,JSON.stringify(prefs));}
+  function apply(){
+    root.style.fontSize=prefs.font+'%';
+    body.classList.toggle('dci-a11y-links',!!prefs.links);
+    body.classList.toggle('dci-a11y-dyslexia',!!prefs.dyslexia);
+    body.classList.toggle('dci-a11y-readable-font',!!prefs.readableFont);
+    body.classList.toggle('dci-a11y-highlight-all',!!prefs.highlightAll);
+    body.classList.toggle('dci-a11y-highlight-titles',!!prefs.highlightTitles);
+    body.classList.toggle('dci-a11y-hide-images',!!prefs.hideImages);
+    body.classList.toggle('dci-a11y-stop-animations',!!prefs.stopAnimations);
+    body.classList.toggle('dci-a11y-keyboard',!!prefs.keyboard);
+    body.style.cursor=prefs.cursor?'zoom-in':'';
+    target.style.lineHeight=levels.lineHeight[prefs.lineHeight];
+    target.style.letterSpacing=levels.letterSpacing[prefs.letterSpacing]+'em';
+    target.style.setProperty('--dci-a11y-filter','invert('+ (prefs.invert?100:0) +'%) brightness('+levels.brightness[prefs.brightness]+'%) contrast('+levels.contrast[prefs.contrast]+'%) grayscale('+levels.grayscale[prefs.grayscale]+'%) saturate('+levels.saturation[prefs.saturation]+'%)');
+
+    if(prefs.mute){document.querySelectorAll('audio,video').forEach(function(m){m.muted=true;});}
+
+    wrap.querySelectorAll('.dci-a11y-btn').forEach(function(btn){
+      var a=btn.dataset.a11yAction;
+      var active=(a==='links'&&prefs.links)||(a==='dyslexia'&&prefs.dyslexia)||(a==='cursor'&&prefs.cursor)||(a==='invert'&&prefs.invert)||(a==='brightness'&&prefs.brightness>0)||(a==='contrast'&&prefs.contrast>0)||(a==='grayscale'&&prefs.grayscale>0)||(a==='saturation'&&prefs.saturation>0)||(a==='readable-font'&&prefs.readableFont)||(a==='highlight-all'&&prefs.highlightAll)||(a==='highlight-titles'&&prefs.highlightTitles)||(a==='hide-images'&&prefs.hideImages)||(a==='mute'&&prefs.mute)||(a==='stop-animations'&&prefs.stopAnimations)||(a==='keyboard'&&prefs.keyboard)||(a==='line-height'&&prefs.lineHeight>0)||(a==='letter-spacing'&&prefs.letterSpacing>0);
+      btn.classList.toggle('is-active',active);
+    });
+  }
+  function speak(){if(!('speechSynthesis' in window)) return; window.speechSynthesis.cancel(); var t=(window.getSelection&&window.getSelection().toString())||((document.querySelector('main')||body).innerText||'').slice(0,2200); if(!t) return; var u=new SpeechSynthesisUtterance(t); u.lang='it-IT'; window.speechSynthesis.speak(u);}
+  toggle.addEventListener('click',function(){var open=panel.hidden; panel.hidden=!open; toggle.setAttribute('aria-expanded',open?'true':'false');});
+  wrap.addEventListener('click',function(e){var b=e.target.closest('.dci-a11y-btn'); if(!b) return; var a=b.dataset.a11yAction;
+    if(a==='font-up') prefs.font=clamp(prefs.font+10,90,130);
+    if(a==='font-down') prefs.font=clamp(prefs.font-10,90,130);
+    if(a==='cursor') prefs.cursor=!prefs.cursor;
+    if(a==='links') prefs.links=!prefs.links;
+    if(a==='dyslexia') prefs.dyslexia=!prefs.dyslexia;
+    if(a==='readable-font') prefs.readableFont=!prefs.readableFont;
+    if(a==='highlight-all') prefs.highlightAll=!prefs.highlightAll;
+    if(a==='highlight-titles') prefs.highlightTitles=!prefs.highlightTitles;
+    if(a==='hide-images') prefs.hideImages=!prefs.hideImages;
+    if(a==='mute') prefs.mute=!prefs.mute;
+    if(a==='stop-animations') prefs.stopAnimations=!prefs.stopAnimations;
+    if(a==='keyboard') prefs.keyboard=!prefs.keyboard;
+    if(a==='invert') prefs.invert=!prefs.invert;
+    if(a==='brightness') cycle('brightness');
+    if(a==='contrast') cycle('contrast');
+    if(a==='saturation') cycle('saturation');
+    if(a==='grayscale') cycle('grayscale');
+    if(a==='line-height') cycle('lineHeight');
+    if(a==='letter-spacing') cycle('letterSpacing');
+    if(a==='read') speak();
+    if(a==='reset'){prefs={font:100,cursor:false,links:false,dyslexia:false,invert:false,brightness:0,contrast:0,saturation:0,grayscale:0,readableFont:false,highlightAll:false,highlightTitles:false,hideImages:false,mute:false,stopAnimations:false,keyboard:false,lineHeight:0,letterSpacing:0}; if(window.speechSynthesis) window.speechSynthesis.cancel();}
+    save(); apply();
+  });
+  apply();
+})();

--- a/functions.php
+++ b/functions.php
@@ -171,6 +171,7 @@ function dci_scripts() {
 
     wp_enqueue_style( 'dci-font', get_template_directory_uri() . '/assets/css/fonts.css', array('dci-comuni'));
     wp_enqueue_style( 'dci-wp-style', get_template_directory_uri()."/style.css", array('dci-comuni'));
+    wp_enqueue_style( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/css/accessibility-toolbar.css', array('dci-wp-style'), false );
 
 
     wp_enqueue_script( 'dci-modernizr', get_template_directory_uri() . '/assets/js/modernizr.custom.js');
@@ -195,6 +196,8 @@ function dci_scripts() {
         wp_enqueue_script( 'dci-boostrap-italia-min-js', get_template_directory_uri() . '/assets/js/bootstrap-italia.bundle.min.js', array(), false, true);
     }
 	wp_enqueue_script( 'dci-comuni', get_template_directory_uri() . '/assets/js/comuni.js', array(), false, true);
+	wp_enqueue_script( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/js/accessibility-toolbar.js', array(), false, true);
+	wp_script_add_data( 'dci-accessibility-toolbar', 'defer', true );
 	wp_add_inline_script( 'dci-comuni', 'window.wpRestApi = "' . get_rest_url() . '"', 'before' );
 
 	wp_enqueue_script( 'dci-jquery-easing', get_template_directory_uri() . '/assets/js/components/jquery-easing/jquery.easing.js', array(), false, true);

--- a/header.php
+++ b/header.php
@@ -260,6 +260,7 @@ $current_group = dci_get_current_group();
 </header>
 
 <?php get_template_part("template-parts/common/search-modal"); ?>
+<?php get_template_part("template-parts/common/accessibility-toolbar"); ?>
 <?php
 if(!is_user_logged_in())
     get_template_part("template-parts/common/access-modal");

--- a/inc/admin/options/opzioni_comune.php
+++ b/inc/admin/options/opzioni_comune.php
@@ -208,6 +208,19 @@ function dci_register_comune_options(){
         ),
     ));
 
+
+    $header_options->add_field(array(
+        'id'      => $prefix . 'ck_accessibility_toolbar',
+        'name'    => __('Mostra toolbar accessibilità', 'design_comuni_italia'),
+        'desc'    => __('Abilita/disabilita la toolbar accessibilità frontend (minimizzata in basso a sinistra).', 'design_comuni_italia'),
+        'type'    => 'radio_inline',
+        'default' => 'true',
+        'options' => array(
+            'true'  => __('Sì', 'design_comuni_italia'),
+            'false' => __('No', 'design_comuni_italia'),
+        ),
+    ));
+
     $header_options->add_field(array(
         'id'      => $prefix . 'ck_collegamenti_contenuti',
         'name'    => __('Collegamenti Automaticament Contenuti Correlati', 'design_comuni_italia'),

--- a/inc/filters.php
+++ b/inc/filters.php
@@ -36,3 +36,91 @@ function dci_vivere_il_comune_post_link( $post_link, $id = 0 ){
     return $post_link;
 }
 add_filter( 'post_type_link', 'dci_vivere_il_comune_post_link', 1, 3 );
+/**
+ * Build sanitized alt/title text for images based on related post title.
+ *
+ * Removes special characters, normalizes whitespace and limits length.
+ *
+ * @param int $post_id
+ * @return string
+ */
+function dci_get_sanitized_image_text_from_post( $post_id ) {
+    $max_length = 90;
+    $title = '';
+
+    if ( $post_id ) {
+        $title = get_the_title( $post_id );
+    }
+
+    if ( empty( $title ) && is_singular() ) {
+        $title = get_the_title();
+    }
+
+    if ( empty( $title ) ) {
+        return '';
+    }
+
+    $title = wp_strip_all_tags( $title );
+    $title = preg_replace( '/[^\p{L}\p{N}\s\-]/u', ' ', $title );
+    $title = preg_replace( '/\s+/u', ' ', $title );
+    $title = trim( $title );
+
+    if ( function_exists( 'mb_strlen' ) && function_exists( 'mb_substr' ) ) {
+        if ( mb_strlen( $title ) > $max_length ) {
+            $title = rtrim( mb_substr( $title, 0, $max_length - 1 ) ) . '…';
+        }
+    } elseif ( strlen( $title ) > $max_length ) {
+        $title = rtrim( substr( $title, 0, $max_length - 1 ) ) . '…';
+    }
+
+    return $title;
+}
+
+/**
+ * Ensure attachment images have meaningful alt and title attributes.
+ *
+ * @param array        $attr
+ * @param WP_Post      $attachment
+ * @param string|array $size
+ * @return array
+ */
+function dci_enforce_image_alt_and_title_attributes( $attr, $attachment, $size ) {
+    if ( is_admin() || wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+        return $attr;
+    }
+
+    // In produzione tocchiamo solo le immagini contenuto (featured), evitando asset tecnici/icons.
+    if ( empty( $attr['class'] ) || strpos( $attr['class'], 'wp-post-image' ) === false ) {
+        return $attr;
+    }
+
+    $related_post_id = get_the_ID();
+
+    if ( ! $related_post_id ) {
+        $queried_object_id = get_queried_object_id();
+        $related_post_id   = $queried_object_id ? $queried_object_id : 0;
+    }
+
+    if ( $related_post_id && get_post_thumbnail_id( $related_post_id ) !== (int) $attachment->ID ) {
+        $related_post_id = 0;
+    }
+
+    $fallback_text = dci_get_sanitized_image_text_from_post( $related_post_id );
+
+    if ( empty( $fallback_text ) ) {
+        $fallback_text = dci_get_sanitized_image_text_from_post( $attachment->post_parent );
+    }
+
+    if ( ! empty( $fallback_text ) ) {
+        if ( empty( $attr['alt'] ) ) {
+            $attr['alt'] = $fallback_text;
+        }
+
+        if ( empty( $attr['title'] ) ) {
+            $attr['title'] = ! empty( $attr['alt'] ) ? $attr['alt'] : $fallback_text;
+        }
+    }
+
+    return $attr;
+}
+add_filter( 'wp_get_attachment_image_attributes', 'dci_enforce_image_alt_and_title_attributes', 10, 3 );

--- a/template-parts/common/accessibility-toolbar.php
+++ b/template-parts/common/accessibility-toolbar.php
@@ -1,0 +1,34 @@
+<?php
+$enabled_raw = dci_get_option( 'ck_accessibility_toolbar', 'dci_options', 'true' );
+$enabled     = filter_var( $enabled_raw, FILTER_VALIDATE_BOOLEAN );
+
+if ( ! $enabled ) {
+    return;
+}
+?>
+<div class="dci-a11y" data-dci-a11y>
+    <button type="button" class="dci-a11y-toggle" data-a11y-action="toggle" aria-expanded="false" aria-controls="dci-a11y-panel">⚙️ Accessibilità</button>
+    <div id="dci-a11y-panel" class="dci-a11y-panel" hidden>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="font-up"><span class="dci-a11y-ico">🔎</span><span>Aumenta testo</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="font-down"><span class="dci-a11y-ico">🔍</span><span>Riduci testo</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="line-height"><span class="dci-a11y-ico">↕️</span><span>Interlinea</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="letter-spacing"><span class="dci-a11y-ico">↔️</span><span>Spaziatura</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="readable-font"><span class="dci-a11y-ico">🔤</span><span>Font leggibile</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="dyslexia"><span class="dci-a11y-ico">🅰️</span><span>Font dislessia</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="cursor"><span class="dci-a11y-ico">🖱️</span><span>Cursore</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="keyboard"><span class="dci-a11y-ico">⌨️</span><span>Tastiera</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="links"><span class="dci-a11y-ico">🔗</span><span>Evidenzia link</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="highlight-all"><span class="dci-a11y-ico">💡</span><span>Evidenzia tutto</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="highlight-titles"><span class="dci-a11y-ico">🏷️</span><span>Evidenzia titoli</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="hide-images"><span class="dci-a11y-ico">🖼️</span><span>Nascondi immagini</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="invert"><span class="dci-a11y-ico">◐</span><span>Inverti colori</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="brightness"><span class="dci-a11y-ico">☀️</span><span>Luminosità</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="contrast"><span class="dci-a11y-ico">◑</span><span>Contrasto</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="grayscale"><span class="dci-a11y-ico">◻️</span><span>Scala di grigi</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="saturation"><span class="dci-a11y-ico">🎨</span><span>Saturazione</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="read"><span class="dci-a11y-ico">🔊</span><span>Lettura vocale</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="mute"><span class="dci-a11y-ico">🔇</span><span>Disattiva suoni</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="stop-animations"><span class="dci-a11y-ico">⏹️</span><span>Ferma animazioni</span></button>
+        <button type="button" class="dci-a11y-btn dci-a11y-btn-reset" data-a11y-action="reset"><span class="dci-a11y-ico">♻️</span><span>Ripristina</span></button>
+    </div>
+</div>


### PR DESCRIPTION
### Motivation
- Provide an interactive, front-end accessibility toolbar so users can adjust font size, contrast, spacing, visual highlights and other accessibility-related settings. 
- Allow site administrators to enable or disable the toolbar via the theme options. 
- Improve image semantics by providing sanitized fallback `alt` and `title` text based on related post titles when attributes are missing.

### Description
- Add toolbar assets: new CSS `assets/css/accessibility-toolbar.css` and JS `assets/js/accessibility-toolbar.js` implementing persistent preferences, various visual controls, and a vocal reader. 
- Add template partial `template-parts/common/accessibility-toolbar.php` and include it in `header.php` so the toolbar is rendered when enabled. 
- Enqueue and defer the new assets from `functions.php` by registering `dci-accessibility-toolbar` stylesheet and script and adding the inline theme path script. 
- Add admin option `ck_accessibility_toolbar` in `inc/admin/options/opzioni_comune.php` to toggle the toolbar in the front-end. 
- Add image accessibility helpers in `inc/filters.php`: `dci_get_sanitized_image_text_from_post()` to sanitize/trim titles and `dci_enforce_image_alt_and_title_attributes()` which populates missing `alt`/`title` for `wp-post-image` attachments and is hooked to `wp_get_attachment_image_attributes`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107f9e9db883329fdae06254799ee3)