### PR TITLE
Add accessibility toolbar and frontend accessibility enhancements

### DIFF
--- a/assets/css/accessibility-toolbar.css
+++ b/assets/css/accessibility-toolbar.css
@@ -1,0 +1,26 @@
+.dci-a11y{position:fixed;left:12px;bottom:12px;z-index:9998;font-family:Inter,Arial,sans-serif}
+.dci-a11y-toggle{border:0;background:linear-gradient(135deg,#0d3b79,#1f5daa);color:#fff;border-radius:999px;padding:10px 16px;font-weight:700;box-shadow:0 6px 20px rgba(13,59,121,.3)}
+.dci-a11y-panel{margin-top:10px;background:#f7f9fc;border:1px solid #dbe3ef;border-radius:12px;padding:10px;display:grid;grid-template-columns:repeat(2,minmax(150px,1fr));gap:8px;max-width:390px;max-height:62vh;overflow:auto;box-shadow:0 10px 26px rgba(10,32,66,.18)}
+.dci-a11y-btn{cursor:pointer;border:1px solid #cbd6e5;background:#fff;color:#1d2c3f;padding:10px;border-radius:10px;font-weight:600;min-height:56px;display:flex;flex-wrap:wrap;align-items:center;gap:6px 8px;text-align:left;line-height:1.2}
+.dci-a11y-ico{font-size:16px;display:inline-flex;width:18px;justify-content:center}
+.dci-a11y-btn:hover{background:#eef4ff}
+.dci-a11y-btn.is-active{background:#0d3b79;color:#fff;border-color:#0d3b79}
+.dci-a11y-btn-reset{background:#fff7f7;border-color:#f1c7c7}
+body.dci-a11y-links a{text-decoration:underline!important;text-decoration-thickness:2px!important}
+body.dci-a11y-dyslexia{font-family:Verdana,Arial,sans-serif!important;letter-spacing:.02em;word-spacing:.06em;line-height:1.7}
+body.dci-a11y-readable-font{font-family:Arial,Helvetica,sans-serif!important}
+body.dci-a11y-highlight-all p,body.dci-a11y-highlight-all li,body.dci-a11y-highlight-all span{background:#fff4a3!important}
+body.dci-a11y-highlight-titles h1,body.dci-a11y-highlight-titles h2,body.dci-a11y-highlight-titles h3,body.dci-a11y-highlight-titles h4{background:#fff4a3!important}
+body.dci-a11y-hide-images img{display:none!important}
+body.dci-a11y-stop-animations *,body.dci-a11y-stop-animations *::before,body.dci-a11y-stop-animations *::after{animation:none!important;transition:none!important}
+body.dci-a11y-keyboard *:focus{outline:3px solid #0d3b79!important;outline-offset:2px!important}
+[data-dci-a11y-target='1']{filter:var(--dci-a11y-filter,none)}
+@media (max-width:767px){.dci-a11y{left:8px;right:8px;bottom:8px}.dci-a11y-toggle{width:100%}.dci-a11y-panel{max-width:none;grid-template-columns:1fr 1fr;max-height:55vh}}
+
+body.dci-a11y-cursor-1, body.dci-a11y-cursor-1 *{cursor:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M4 2l14 9l-6 1l3.5 8l-2.2 1l-3.5-8l-4.3 4.3z'/%3E%3C/svg%3E") 3 3, auto !important;}
+body.dci-a11y-cursor-2, body.dci-a11y-cursor-2 *{cursor:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='38' height='38' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M4 2l14 9l-6 1l3.5 8l-2.2 1l-3.5-8l-4.3 4.3z'/%3E%3C/svg%3E") 3 3, auto !important;}
+body.dci-a11y-cursor-3, body.dci-a11y-cursor-3 *{cursor:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='46' height='46' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M4 2l14 9l-6 1l3.5 8l-2.2 1l-3.5-8l-4.3 4.3z'/%3E%3C/svg%3E") 3 3, auto !important;}
+
+.dci-a11y-level{display:flex;gap:4px;margin-left:26px;flex-basis:100%}
+.dci-a11y-level i{display:inline-block;width:12px;height:3px;border-radius:2px;background:#b7c3d6;opacity:.6}
+.dci-a11y-level i.is-on{background:currentColor;opacity:1}

--- a/assets/js/accessibility-toolbar.js
+++ b/assets/js/accessibility-toolbar.js
@@ -1,0 +1,112 @@
+(function(){
+  var wrap=document.querySelector('[data-dci-a11y]'); if(!wrap) return;
+  var KEY='dciA11yPrefs',root=document.documentElement,body=document.body;
+  var panel=wrap.querySelector('#dci-a11y-panel'),toggle=wrap.querySelector('[data-a11y-action="toggle"]');
+  var target=document.querySelector('main')||document.getElementById('main')||body;
+  target.setAttribute('data-dci-a11y-target','1');
+
+  var levels={brightness:[100,108,116,124],contrast:[100,108,116,124],saturation:[100,90,110,125],grayscale:[0,35,70,100],lineHeight:[1.5,1.7,1.9,2.1],letterSpacing:[0,0.03,0.06,0.09],cursor:[0,1,2,3]};
+  var prefs={font:100,cursor:0,links:false,dyslexia:false,invert:false,brightness:0,contrast:0,saturation:0,grayscale:0,readableFont:false,highlightAll:false,highlightTitles:false,hideImages:false,mute:false,stopAnimations:false,keyboard:false,lineHeight:0,letterSpacing:0};
+
+  try{prefs=Object.assign(prefs,JSON.parse(localStorage.getItem(KEY)||'{}'));}catch(e){}
+
+  function clamp(n,min,max){return Math.min(max,Math.max(min,n));}
+  function cycle(name){prefs[name]=(prefs[name]+1)%levels[name].length;}
+  function save(){localStorage.setItem(KEY,JSON.stringify(prefs));}
+
+
+  function levelInfo(action){
+    if(action==='brightness') return {current:prefs.brightness,max:levels.brightness.length-1};
+    if(action==='contrast') return {current:prefs.contrast,max:levels.contrast.length-1};
+    if(action==='saturation') return {current:prefs.saturation,max:levels.saturation.length-1};
+    if(action==='grayscale') return {current:prefs.grayscale,max:levels.grayscale.length-1};
+    if(action==='line-height') return {current:prefs.lineHeight,max:levels.lineHeight.length-1};
+    if(action==='cursor') return {current:prefs.cursor,max:levels.cursor.length-1};
+    if(action==='letter-spacing') return {current:prefs.letterSpacing,max:levels.letterSpacing.length-1};
+    if(action==='font-up'||action==='font-down') return {current:Math.max(0,Math.round((prefs.font-90)/10)),max:4};
+    return null;
+  }
+
+  function isActiveAction(a){
+    return (a==='links'&&prefs.links)||(a==='dyslexia'&&prefs.dyslexia)||(a==='cursor'&&prefs.cursor>0)||(a==='invert'&&prefs.invert)||(a==='brightness'&&prefs.brightness>0)||(a==='contrast'&&prefs.contrast>0)||(a==='grayscale'&&prefs.grayscale>0)||(a==='saturation'&&prefs.saturation>0)||(a==='readable-font'&&prefs.readableFont)||(a==='highlight-all'&&prefs.highlightAll)||(a==='highlight-titles'&&prefs.highlightTitles)||(a==='hide-images'&&prefs.hideImages)||(a==='mute'&&prefs.mute)||(a==='stop-animations'&&prefs.stopAnimations)||(a==='keyboard'&&prefs.keyboard)||(a==='line-height'&&prefs.lineHeight>0)||(a==='letter-spacing'&&prefs.letterSpacing>0);
+  }
+
+  function apply(){
+    root.style.fontSize=prefs.font+'%';
+    body.classList.toggle('dci-a11y-links',!!prefs.links);
+    body.classList.toggle('dci-a11y-dyslexia',!!prefs.dyslexia);
+    body.classList.toggle('dci-a11y-readable-font',!!prefs.readableFont);
+    body.classList.toggle('dci-a11y-highlight-all',!!prefs.highlightAll);
+    body.classList.toggle('dci-a11y-highlight-titles',!!prefs.highlightTitles);
+    body.classList.toggle('dci-a11y-hide-images',!!prefs.hideImages);
+    body.classList.toggle('dci-a11y-stop-animations',!!prefs.stopAnimations);
+    body.classList.toggle('dci-a11y-keyboard',!!prefs.keyboard);
+    body.classList.remove('dci-a11y-cursor-1','dci-a11y-cursor-2','dci-a11y-cursor-3');
+    if(prefs.cursor>0){body.classList.add('dci-a11y-cursor-'+prefs.cursor);}
+
+    target.style.lineHeight=levels.lineHeight[prefs.lineHeight];
+    target.style.letterSpacing=levels.letterSpacing[prefs.letterSpacing]+'em';
+    target.style.setProperty('--dci-a11y-filter','invert('+ (prefs.invert?100:0) +'%) brightness('+levels.brightness[prefs.brightness]+'%) contrast('+levels.contrast[prefs.contrast]+'%) grayscale('+levels.grayscale[prefs.grayscale]+'%) saturate('+levels.saturation[prefs.saturation]+'%)');
+
+    document.querySelectorAll('audio,video').forEach(function(m){ m.muted=!!prefs.mute; });
+
+    wrap.querySelectorAll('.dci-a11y-btn').forEach(function(btn){
+      var a=btn.dataset.a11yAction;
+      var active=isActiveAction(a);
+      btn.classList.toggle('is-active',active);
+      btn.setAttribute('aria-pressed',active?'true':'false');
+      var lvl=levelInfo(a);
+      var dots=btn.querySelectorAll('.dci-a11y-level i');
+      if(dots.length&&lvl){
+        dots.forEach(function(d,i){ d.classList.toggle('is-on', i < lvl.current); });
+      }
+    });
+  }
+
+  function speak(){
+    if(!('speechSynthesis' in window)) return;
+    window.speechSynthesis.cancel();
+    var t=(window.getSelection&&window.getSelection().toString())||((document.querySelector('main')||body).innerText||'').slice(0,2200);
+    if(!t) return;
+    var u=new SpeechSynthesisUtterance(t); u.lang='it-IT'; window.speechSynthesis.speak(u);
+  }
+
+  function handleAction(a){
+    if(a==='font-up') prefs.font=clamp(prefs.font+10,90,130);
+    if(a==='font-down') prefs.font=clamp(prefs.font-10,90,130);
+    if(a==='cursor') cycle('cursor');
+    if(a==='links') prefs.links=!prefs.links;
+    if(a==='dyslexia') prefs.dyslexia=!prefs.dyslexia;
+    if(a==='readable-font') prefs.readableFont=!prefs.readableFont;
+    if(a==='highlight-all') prefs.highlightAll=!prefs.highlightAll;
+    if(a==='highlight-titles') prefs.highlightTitles=!prefs.highlightTitles;
+    if(a==='hide-images') prefs.hideImages=!prefs.hideImages;
+    if(a==='mute') prefs.mute=!prefs.mute;
+    if(a==='stop-animations') prefs.stopAnimations=!prefs.stopAnimations;
+    if(a==='keyboard') prefs.keyboard=!prefs.keyboard;
+    if(a==='invert') prefs.invert=!prefs.invert;
+    if(a==='brightness') cycle('brightness');
+    if(a==='contrast') cycle('contrast');
+    if(a==='saturation') cycle('saturation');
+    if(a==='grayscale') cycle('grayscale');
+    if(a==='line-height') cycle('lineHeight');
+    if(a==='letter-spacing') cycle('letterSpacing');
+    if(a==='read') speak();
+    if(a==='reset'){
+      prefs={font:100,cursor:0,links:false,dyslexia:false,invert:false,brightness:0,contrast:0,saturation:0,grayscale:0,readableFont:false,highlightAll:false,highlightTitles:false,hideImages:false,mute:false,stopAnimations:false,keyboard:false,lineHeight:0,letterSpacing:0};
+      if(window.speechSynthesis) window.speechSynthesis.cancel();
+    }
+    save(); apply();
+  }
+
+  toggle.addEventListener('click',function(){var open=panel.hidden; panel.hidden=!open; toggle.setAttribute('aria-expanded',open?'true':'false');});
+
+  wrap.addEventListener('click',function(e){
+    var b=e.target.closest('.dci-a11y-btn');
+    if(!b) return;
+    e.preventDefault();
+    handleAction(b.dataset.a11yAction);
+  });
+
+  apply();
+})();

--- a/functions.php
+++ b/functions.php
@@ -171,6 +171,7 @@ function dci_scripts() {
 
     wp_enqueue_style( 'dci-font', get_template_directory_uri() . '/assets/css/fonts.css', array('dci-comuni'));
     wp_enqueue_style( 'dci-wp-style', get_template_directory_uri()."/style.css", array('dci-comuni'));
+    wp_enqueue_style( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/css/accessibility-toolbar.css', array('dci-wp-style'), false );
 
 
     wp_enqueue_script( 'dci-modernizr', get_template_directory_uri() . '/assets/js/modernizr.custom.js');
@@ -195,6 +196,8 @@ function dci_scripts() {
         wp_enqueue_script( 'dci-boostrap-italia-min-js', get_template_directory_uri() . '/assets/js/bootstrap-italia.bundle.min.js', array(), false, true);
     }
 	wp_enqueue_script( 'dci-comuni', get_template_directory_uri() . '/assets/js/comuni.js', array(), false, true);
+	wp_enqueue_script( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/js/accessibility-toolbar.js', array(), false, true);
+	wp_script_add_data( 'dci-accessibility-toolbar', 'defer', true );
 	wp_add_inline_script( 'dci-comuni', 'window.wpRestApi = "' . get_rest_url() . '"', 'before' );
 
 	wp_enqueue_script( 'dci-jquery-easing', get_template_directory_uri() . '/assets/js/components/jquery-easing/jquery.easing.js', array(), false, true);

--- a/header.php
+++ b/header.php
@@ -260,6 +260,7 @@ $current_group = dci_get_current_group();
 </header>
 
 <?php get_template_part("template-parts/common/search-modal"); ?>
+<?php get_template_part("template-parts/common/accessibility-toolbar"); ?>
 <?php
 if(!is_user_logged_in())
     get_template_part("template-parts/common/access-modal");

--- a/inc/admin/options/opzioni_comune.php
+++ b/inc/admin/options/opzioni_comune.php
@@ -208,6 +208,19 @@ function dci_register_comune_options(){
         ),
     ));
 
+
+    $header_options->add_field(array(
+        'id'      => $prefix . 'ck_accessibility_toolbar',
+        'name'    => __('Mostra toolbar accessibilità', 'design_comuni_italia'),
+        'desc'    => __('Abilita/disabilita la toolbar accessibilità frontend (minimizzata in basso a sinistra).', 'design_comuni_italia'),
+        'type'    => 'radio_inline',
+        'default' => 'true',
+        'options' => array(
+            'true'  => __('Sì', 'design_comuni_italia'),
+            'false' => __('No', 'design_comuni_italia'),
+        ),
+    ));
+
     $header_options->add_field(array(
         'id'      => $prefix . 'ck_collegamenti_contenuti',
         'name'    => __('Collegamenti Automaticament Contenuti Correlati', 'design_comuni_italia'),

--- a/inc/filters.php
+++ b/inc/filters.php
@@ -36,3 +36,186 @@ function dci_vivere_il_comune_post_link( $post_link, $id = 0 ){
     return $post_link;
 }
 add_filter( 'post_type_link', 'dci_vivere_il_comune_post_link', 1, 3 );
+/**
+ * Build sanitized alt/title text for images based on related post title.
+ *
+ * Removes special characters, normalizes whitespace and limits length.
+ *
+ * @param int $post_id
+ * @return string
+ */
+function dci_get_sanitized_image_text_from_post( $post_id ) {
+    $max_length = 90;
+    $title = '';
+
+    if ( $post_id ) {
+        $title = get_the_title( $post_id );
+    }
+
+    if ( empty( $title ) && is_singular() ) {
+        $title = get_the_title();
+    }
+
+    if ( empty( $title ) ) {
+        return '';
+    }
+
+    $title = wp_strip_all_tags( $title );
+    $title = preg_replace( '/[^\p{L}\p{N}\s\-]/u', ' ', $title );
+    $title = preg_replace( '/\s+/u', ' ', $title );
+    $title = trim( $title );
+
+    if ( function_exists( 'mb_strlen' ) && function_exists( 'mb_substr' ) ) {
+        if ( mb_strlen( $title ) > $max_length ) {
+            $title = rtrim( mb_substr( $title, 0, $max_length - 1 ) ) . '…';
+        }
+    } elseif ( strlen( $title ) > $max_length ) {
+        $title = rtrim( substr( $title, 0, $max_length - 1 ) ) . '…';
+    }
+
+    return $title;
+}
+
+/**
+ * Ensure attachment images have meaningful alt and title attributes.
+ *
+ * @param array        $attr
+ * @param WP_Post      $attachment
+ * @param string|array $size
+ * @return array
+ */
+function dci_enforce_image_alt_and_title_attributes( $attr, $attachment, $size ) {
+    if ( is_admin() || wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+        return $attr;
+    }
+
+    $related_post_id = get_the_ID();
+
+    if ( ! $related_post_id ) {
+        $queried_object_id = get_queried_object_id();
+        $related_post_id   = $queried_object_id ? $queried_object_id : 0;
+    }
+
+    $fallback_text = dci_get_sanitized_image_text_from_post( $related_post_id );
+
+    if ( empty( $fallback_text ) ) {
+        $fallback_text = dci_get_sanitized_image_text_from_post( $attachment->post_parent );
+    }
+
+    if ( empty( $fallback_text ) ) {
+        $fallback_text = dci_get_sanitized_image_text_from_post( $attachment->ID );
+    }
+
+    if ( ! empty( $fallback_text ) ) {
+        $attr['alt']   = ! empty( $attr['alt'] ) ? $attr['alt'] : $fallback_text;
+        $attr['title'] = ! empty( $attr['title'] ) ? $attr['title'] : $attr['alt'];
+    }
+
+    return $attr;
+}
+add_filter( 'wp_get_attachment_image_attributes', 'dci_enforce_image_alt_and_title_attributes', 10, 3 );
+
+/**
+ * Add missing title attributes to links/buttons and enforce alt/title on img tags in frontend HTML output.
+ * This supports institutional accessibility checklists requiring explicit attributes.
+ */
+function dci_accessibility_enhance_frontend_markup( $html ) {
+    if ( empty( $html ) ) {
+        return $html;
+    }
+
+    if ( ! class_exists( 'DOMDocument' ) ) {
+        return $html;
+    }
+
+    libxml_use_internal_errors( true );
+    $dom = new DOMDocument();
+    $loaded = $dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+    if ( ! $loaded ) {
+        libxml_clear_errors();
+        return $html;
+    }
+
+    // IMG: ensure both alt and title are present.
+    $imgs = $dom->getElementsByTagName( 'img' );
+    foreach ( $imgs as $img ) {
+        $alt   = trim( (string) $img->getAttribute( 'alt' ) );
+        $title = trim( (string) $img->getAttribute( 'title' ) );
+
+        if ( empty( $title ) ) {
+            $title = $alt;
+        }
+
+        if ( empty( $alt ) && ! empty( $title ) ) {
+            $alt = $title;
+        }
+
+        if ( empty( $alt ) || empty( $title ) ) {
+            $src = (string) $img->getAttribute( 'src' );
+            if ( ! empty( $src ) ) {
+                $file_label = trim( preg_replace( '/[-_]+/', ' ', pathinfo( $src, PATHINFO_FILENAME ) ) );
+                if ( empty( $alt ) ) {
+                    $alt = $file_label;
+                }
+                if ( empty( $title ) ) {
+                    $title = $file_label;
+                }
+            }
+        }
+
+        if ( ! empty( $alt ) ) {
+            $img->setAttribute( 'alt', $alt );
+        }
+        if ( ! empty( $title ) ) {
+            $img->setAttribute( 'title', $title );
+        }
+    }
+
+    // A, BUTTON: add title if missing from aria-label or visible text.
+    foreach ( array( 'a', 'button' ) as $tag ) {
+        $nodes = $dom->getElementsByTagName( $tag );
+        foreach ( $nodes as $node ) {
+            $title = trim( (string) $node->getAttribute( 'title' ) );
+            if ( ! empty( $title ) ) {
+                continue;
+            }
+
+            $label = trim( (string) $node->getAttribute( 'aria-label' ) );
+            if ( empty( $label ) ) {
+                $label = trim( preg_replace( '/\s+/u', ' ', $node->textContent ) );
+            }
+
+            if ( empty( $label ) && $tag === 'a' ) {
+                $href = trim( (string) $node->getAttribute( 'href' ) );
+                if ( ! empty( $href ) ) {
+                    $path = parse_url( $href, PHP_URL_PATH );
+                    $label = trim( preg_replace( '/[-_]+/', ' ', basename( (string) $path ) ) );
+                }
+            }
+
+            if ( empty( $label ) && $tag === 'button' ) {
+                $label = trim( (string) $node->getAttribute( 'value' ) );
+            }
+
+            if ( ! empty( $label ) ) {
+                $node->setAttribute( 'title', $label );
+            }
+        }
+    }
+
+    $result = $dom->saveHTML();
+    libxml_clear_errors();
+
+    return ! empty( $result ) ? $result : $html;
+}
+
+function dci_accessibility_start_output_buffer() {
+    if ( is_admin() || wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+        return;
+    }
+
+    if ( ! ob_get_level() ) {
+        ob_start( 'dci_accessibility_enhance_frontend_markup' );
+    }
+}
+add_action( 'template_redirect', 'dci_accessibility_start_output_buffer', 0 );

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1269,14 +1269,31 @@ if (!function_exists('dci_get_maggioli_services_data')) {
 
 if(!function_exists("dci_get_img")) {
     function dci_get_img( $url, $classes = '') {
-        $img_post = get_post( attachment_url_to_postid($url) );
-        $image_alt = get_post_meta( $img_post->ID, '_wp_attachment_image_alt', true);
-        $image_title = get_the_title( $img_post->ID );
+        $attachment_id = attachment_url_to_postid($url);
+        $img_post = $attachment_id ? get_post( $attachment_id ) : null;
 
-        $img = '<img src="'.$url.'" ';        
-        if ($classes) $img .= 'class="'.$classes.'" ';
-        if ($image_alt) $img .= 'alt="'.$image_alt.'" ';
-        if ($image_title) $img .= 'title="'.$image_title.'" ';
+        $image_title = '';
+        $image_alt = '';
+
+        if ( $img_post && isset( $img_post->ID ) ) {
+            $image_alt   = (string) get_post_meta( $img_post->ID, '_wp_attachment_image_alt', true );
+            $image_title = (string) get_the_title( $img_post->ID );
+        }
+
+        if ( empty( $image_title ) ) {
+            $image_title = trim( preg_replace('/[-_]+/', ' ', pathinfo( (string) $url, PATHINFO_FILENAME ) ) );
+        }
+
+        if ( empty( $image_alt ) ) {
+            $image_alt = $image_title;
+        }
+
+        $img = '<img src="' . esc_url( $url ) . '" ';
+        if ($classes) {
+            $img .= 'class="' . esc_attr( $classes ) . '" ';
+        }
+        $img .= 'alt="' . esc_attr( $image_alt ) . '" ';
+        $img .= 'title="' . esc_attr( $image_title ) . '" ';
         $img .= '/>';
 
         echo $img;

--- a/template-parts/amministrazione-trasparente/atto-concessione/tutti-gli-atti.php
+++ b/template-parts/amministrazione-trasparente/atto-concessione/tutti-gli-atti.php
@@ -1,13 +1,13 @@
 <?php
-global $wpdb;
+global $wpdb, $wp;
 
 // Lettura parametri da URL
 $max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 10;
 $main_search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
-$paged = max(1, (int) get_query_var('paged'));
-if ($paged < 2) {
-    $paged = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : (isset($_GET['page']) ? max(1, intval($_GET['page'])) : 1);
-}
+$paged_from_query = max(1, (int) get_query_var('paged'));
+$paged_from_page  = max(1, (int) get_query_var('page'));
+$paged_from_get   = isset($_GET['paged']) ? max(1, intval($_GET['paged'])) : (isset($_GET['page']) ? max(1, intval($_GET['page'])) : 1);
+$paged = max($paged_from_query, $paged_from_page, $paged_from_get);
 $selected_year = isset($_GET['filter_year']) ? intval($_GET['filter_year']) : 0;
 
 // Anni disponibili
@@ -19,6 +19,40 @@ $years = $wpdb->get_col("
     ORDER BY post_date DESC
 ");
 
+
+$search_post_ids = array();
+if (!empty($main_search_query)) {
+    $search_like = '%' . $wpdb->esc_like($main_search_query) . '%';
+
+    $meta_keys = array(
+        '_dci_atto_concessione_ragione_sociale',
+        '_dci_atto_concessione_codice_fiscale',
+        '_dci_atto_concessione_responsabile',
+        '_dci_atto_concessione_rag_incarico',
+        '_dci_atto_concessione_importo',
+    );
+
+    $meta_placeholders = implode(',', array_fill(0, count($meta_keys), '%s'));
+
+    $sql = "SELECT DISTINCT p.ID
+            FROM {$wpdb->posts} p
+            LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID
+            WHERE p.post_type = 'atto_concessione'
+              AND p.post_status = 'publish'
+              AND (p.post_title LIKE %s OR p.post_content LIKE %s OR (pm.meta_key IN ($meta_placeholders) AND pm.meta_value LIKE %s))";
+
+    $prepared = $wpdb->prepare(
+        $sql,
+        array_merge(array($search_like, $search_like), $meta_keys, array($search_like))
+    );
+
+    $search_post_ids = array_map('intval', (array) $wpdb->get_col($prepared));
+
+    if (empty($search_post_ids)) {
+        $search_post_ids = array(0);
+    }
+}
+
 // Costruzione argomenti WP_Query
 $args = [
     'post_type'      => 'atto_concessione',
@@ -26,10 +60,11 @@ $args = [
     'orderby'        => 'meta_value_num',
     'order'          => 'DESC',
     'paged'          => $paged,
+    'no_found_rows'  => false,
 ];
 
 if (!empty($main_search_query)) {
-    $args['s'] = $main_search_query;
+    $args['post__in'] = $search_post_ids;
 }
 
 if ($selected_year > 0) {
@@ -42,17 +77,16 @@ if ($selected_year > 0) {
 
 $the_query = new WP_Query($args);
 
-// Prendi permalink pagina corrente (senza query string)
-$current_url = get_permalink();
+// Base URL robusta: resta sempre sulla pagina elenco corrente (non sui permalink dei singoli elementi)
+$current_url = home_url( add_query_arg( array(), $wp->request ) );
 
-// Costruiamo la base URL per paginazione mantenendo tutti i parametri
-$base_url = add_query_arg(array(
+$query_args = array(
     'search'      => $main_search_query ? $main_search_query : '',
     'filter_year' => $selected_year > 0 ? $selected_year : 0,
     'max_posts'   => $max_posts,
-    'paged'       => '%#%',
-), $current_url);
+);
 
+$base_url = add_query_arg( array_merge( $query_args, array( 'paged' => '%#%' ) ), $current_url );
 
 ?>
 

--- a/template-parts/argomento/argomenti.php
+++ b/template-parts/argomento/argomenti.php
@@ -12,7 +12,7 @@
             <div class="cmp-card-simple card-wrapper pb-0 rounded border border-light">
               <div class="card shadow-sm rounded">
                 <div class="card-body">
-                    <a class="text-decoration-none" href="<?php echo get_term_link($argomento->term_id); ?>" data-element="topic-element"><h3 class="card-title t-primary title-xlarge"><?php echo $argomento->name; ?></h3></a>
+                    <a class="text-decoration-none" href="<?php echo get_term_link($argomento->term_id); ?>" data-element="topic-element" title="<?php echo esc_attr($argomento->name); ?>"><h3 class="card-title t-primary title-xlarge"><?php echo $argomento->name; ?></h3></a>
                     <p class="titillium text-paragraph mb-0 description">
                         <?php echo $argomento->description; ?>
                     </p>

--- a/template-parts/common/accessibility-toolbar.php
+++ b/template-parts/common/accessibility-toolbar.php
@@ -1,0 +1,34 @@
+<?php
+$enabled_raw = dci_get_option( 'ck_accessibility_toolbar', 'dci_options', 'true' );
+$enabled     = filter_var( $enabled_raw, FILTER_VALIDATE_BOOLEAN );
+
+if ( ! $enabled ) {
+    return;
+}
+?>
+<div class="dci-a11y" data-dci-a11y>
+    <button type="button" class="dci-a11y-toggle" data-a11y-action="toggle" aria-expanded="false" aria-controls="dci-a11y-panel">⚙️ Accessibilità</button>
+    <div id="dci-a11y-panel" class="dci-a11y-panel" hidden>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="font-up" data-level-control="font"><span class="dci-a11y-ico">🔎</span><span class="dci-a11y-label">Aumenta testo</span><span class="dci-a11y-level" aria-hidden="true"><i></i><i></i><i></i><i></i></span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="font-down" data-level-control="font"><span class="dci-a11y-ico">🔍</span><span class="dci-a11y-label">Riduci testo</span><span class="dci-a11y-level" aria-hidden="true"><i></i><i></i><i></i><i></i></span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="line-height" data-level-control="1"><span class="dci-a11y-ico">↕️</span><span class="dci-a11y-label">Interlinea</span><span class="dci-a11y-level" aria-hidden="true"><i></i><i></i><i></i></span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="letter-spacing" data-level-control="1"><span class="dci-a11y-ico">↔️</span><span class="dci-a11y-label">Spaziatura</span><span class="dci-a11y-level" aria-hidden="true"><i></i><i></i><i></i></span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="readable-font"><span class="dci-a11y-ico">🔤</span><span>Font leggibile</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="dyslexia"><span class="dci-a11y-ico">🅰️</span><span>Font dislessia</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="cursor" data-level-control="1"><span class="dci-a11y-ico">🖱️</span><span class="dci-a11y-label">Cursore</span><span class="dci-a11y-level" aria-hidden="true"><i></i><i></i><i></i></span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="keyboard"><span class="dci-a11y-ico">⌨️</span><span>Tastiera</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="links"><span class="dci-a11y-ico">🔗</span><span>Evidenzia link</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="highlight-all"><span class="dci-a11y-ico">💡</span><span>Evidenzia tutto</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="highlight-titles"><span class="dci-a11y-ico">🏷️</span><span>Evidenzia titoli</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="hide-images"><span class="dci-a11y-ico">🖼️</span><span>Nascondi immagini</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="invert"><span class="dci-a11y-ico">◐</span><span>Inverti colori</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="brightness" data-level-control="1"><span class="dci-a11y-ico">☀️</span><span class="dci-a11y-label">Luminosità</span><span class="dci-a11y-level" aria-hidden="true"><i></i><i></i><i></i></span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="contrast" data-level-control="1"><span class="dci-a11y-ico">◑</span><span class="dci-a11y-label">Contrasto</span><span class="dci-a11y-level" aria-hidden="true"><i></i><i></i><i></i></span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="grayscale" data-level-control="1"><span class="dci-a11y-ico">◻️</span><span class="dci-a11y-label">Scala di grigi</span><span class="dci-a11y-level" aria-hidden="true"><i></i><i></i><i></i></span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="saturation" data-level-control="1"><span class="dci-a11y-ico">🎨</span><span class="dci-a11y-label">Saturazione</span><span class="dci-a11y-level" aria-hidden="true"><i></i><i></i><i></i></span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="read"><span class="dci-a11y-ico">🔊</span><span>Lettura vocale</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="mute"><span class="dci-a11y-ico">🔇</span><span>Disattiva suoni</span></button>
+        <button type="button" class="dci-a11y-btn" data-a11y-action="stop-animations"><span class="dci-a11y-ico">⏹️</span><span>Ferma animazioni</span></button>
+        <button type="button" class="dci-a11y-btn dci-a11y-btn-reset" data-a11y-action="reset"><span class="dci-a11y-ico">♻️</span><span>Ripristina</span></button>
+    </div>
+</div>

--- a/template-parts/common/badges-argomenti.php
+++ b/template-parts/common/badges-argomenti.php
@@ -6,7 +6,7 @@ if(count($argomenti)) {?>
 <ul class="d-flex flex-wrap gap-1">
     <?php foreach ( $argomenti as $item ) { ?>
         <li>
-            <a class="chip chip-simple"
+            <a class="chip chip-simple" title="<?php echo esc_attr($item->name); ?>"
             href="<?php echo get_term_link($item); ?>"
             >
                 <span class="chip-label"> 

--- a/template-parts/common/logo-mobile.php
+++ b/template-parts/common/logo-mobile.php
@@ -1,7 +1,13 @@
 <?php
-if (dci_get_option("stemma_comune_mobile")) {
+$stemma_mobile_url = dci_get_option('stemma_comune_mobile');
+if ( ! $stemma_mobile_url ) {
+    return;
+}
+
+$nome_comune = trim( (string) dci_get_option( 'nome_comune' ) );
+$logo_label  = $nome_comune ? 'Stemma del Comune di ' . $nome_comune : 'Stemma del Comune';
 ?>
-<svg width="48" height="48" aria-hidden="true">       
-     <image xlink:href="<?php echo dci_get_option("stemma_comune_mobile");?>" width="48" height="48"/>
+<svg width="48" height="48" role="img" aria-label="<?php echo esc_attr( $logo_label ); ?>">
+    <title><?php echo esc_html( $logo_label ); ?></title>
+    <image xlink:href="<?php echo esc_url( $stemma_mobile_url ); ?>" width="48" height="48" alt="<?php echo esc_attr( $logo_label ); ?>" title="<?php echo esc_attr( $logo_label ); ?>"/>
 </svg>
-<?php } ?>

--- a/template-parts/common/logo.php
+++ b/template-parts/common/logo.php
@@ -1,7 +1,13 @@
 <?php
-if (dci_get_option("stemma_comune")) {
+$stemma_url = dci_get_option('stemma_comune');
+if ( ! $stemma_url ) {
+    return;
+}
+
+$nome_comune = trim( (string) dci_get_option( 'nome_comune' ) );
+$logo_label  = $nome_comune ? 'Stemma del Comune di ' . $nome_comune : 'Stemma del Comune';
 ?>
-<svg width="82" height="82" class="icon" aria-hidden="true">       
-     <image xlink:href="<?php echo dci_get_option("stemma_comune");?>" width="82" height="82"/>    
+<svg width="82" height="82" class="icon" role="img" aria-label="<?php echo esc_attr( $logo_label ); ?>">
+    <title><?php echo esc_html( $logo_label ); ?></title>
+    <image xlink:href="<?php echo esc_url( $stemma_url ); ?>" width="82" height="82" alt="<?php echo esc_attr( $logo_label ); ?>" title="<?php echo esc_attr( $logo_label ); ?>"/>
 </svg>
-<?php } ?>

--- a/template-parts/home/argomenti.php
+++ b/template-parts/home/argomenti.php
@@ -81,7 +81,7 @@ $img = (isset($img_ricavata) && !empty($img_ricavata) && $img_ricavata !== null)
                         $url = get_term_link($argomento->term_id, 'argomenti');
                 ?>
                 
-                <a href="<?php echo esc_url($url); ?>" class="btn-argomento" style="display: inline-flex; align-items: center; gap: 8px;">
+                <a href="<?php echo esc_url($url); ?>" class="btn-argomento" title="Vai all'argomento" style="display: inline-flex; align-items: center; gap: 8px;">
                   <svg class="icon text-primary" style="width:20px; height:30px; display:inline-block; vertical-align:middle;">
                     <use xlink:href="#it-bookmark"></use>
                   </svg>
@@ -93,7 +93,7 @@ $img = (isset($img_ricavata) && !empty($img_ricavata) && $img_ricavata !== null)
                 }
                 ?>
 
-                <a href="<?php echo dci_get_template_page_url('page-templates/argomenti.php'); ?>"  class="btn btn-primary" style="margin-left: 40px;">
+                <a href="<?php echo dci_get_template_page_url('page-templates/argomenti.php'); ?>"  class="btn btn-primary" title="Vai a tutti gli argomenti" style="margin-left: 40px;">
                     Mostra tutti
                 </a>
 


### PR DESCRIPTION
### Motivation
- Provide a built-in accessibility toolbar for users to adjust text size, contrast, cursors, highlights and other presentation settings. 
- Improve frontend markup to ensure images and interactive elements include meaningful `alt`, `title` and ARIA-friendly attributes for institutional accessibility checks. 
- Fix several template/UX issues for more robust pagination, search and accessible labels across templates.

### Description
- Added a self-contained accessibility toolbar: new files `assets/css/accessibility-toolbar.css`, `assets/js/accessibility-toolbar.js`, and template `template-parts/common/accessibility-toolbar.php`, plus inclusion in `header.php` and enqueued CSS/JS in `functions.php` with `defer` for the script.  
- Added admin toggle option `ck_accessibility_toolbar` in `inc/admin/options/opzioni_comune.php` to enable/disable the toolbar.  
- Implemented frontend accessibility enforcement in `inc/filters.php`: new helper `dci_get_sanitized_image_text_from_post()`, `dci_enforce_image_alt_and_title_attributes()` hooked to `wp_get_attachment_image_attributes`, and `dci_accessibility_enhance_frontend_markup()` which runs as an output buffer callback on `template_redirect` to add missing `alt`/`title` and link/button titles.  
- Improved `dci_get_img()` in `inc/utils.php` to safely resolve attachment info, provide deterministic fallback `alt`/`title`, and escape attributes.  
- Multiple template improvements to add accessible attributes and fallbacks: added `title` on topic links (`template-parts/argomento/argomenti.php` and badges), improved logo SVGs with `role`, `title`, `aria-label`, and `alt`/`title` attributes (`template-parts/common/logo.php`, `logo-mobile.php`), and updated home and argomenti templates to include explicit titles on buttons/links.  
- Enhanced `template-parts/amministrazione-trasparente/atto-concessione/tutti-gli-atti.php` with more robust paged calculation, improved search by joining postmeta and searching specific meta keys, and a safer base URL construction for pagination.  

### Testing
- Ran PHP syntax checks (`php -l`) on modified PHP files and they passed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107f9e9db883329fdae06254799ee3)