### PR TITLE
Refine async template cache invalidation, cache feed page ID, and harden queries/timeouts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -170,32 +170,49 @@ function dci_async_template_parts_cache_version() {
     return $version;
 }
 
-function dci_bump_async_template_parts_cache_version($option = '') {
-    $ignored_options = array(
-        'dci_async_template_parts_cache_version',
-        'wpc_home_count',
-        'wpc_home_daily_counts',
-        'dci_calendar_cache_version',
+function dci_bump_async_template_parts_cache_version() {
+    update_option('dci_async_template_parts_cache_version', str_replace('.', '', (string) microtime(true)), false);
+}
+
+function dci_maybe_bump_async_template_parts_cache_version_on_option($option) {
+    $cache_sensitive_options = array(
+        'accesso_rapido',
+        'amministrazione',
+        'argomenti',
+        'assistenza',
+        'dci_options',
+        'documenti',
+        'footer',
+        'Galleria',
+        'galleria',
+        'home_messages',
+        'homepage',
+        'link_utili',
+        'luoghi',
+        'multimedia',
+        'novita',
+        'ricerca',
+        'servizi',
+        'socials',
+        'strip_home',
+        'trasparenza',
+        'vivi',
     );
 
-    if (is_string($option) && (
-        in_array($option, $ignored_options, true)
-        || strpos($option, '_transient_') === 0
-        || strpos($option, '_site_transient_') === 0
-    )) {
+    if (!in_array((string) $option, $cache_sensitive_options, true)) {
         return;
     }
 
-    update_option('dci_async_template_parts_cache_version', str_replace('.', '', (string) microtime(true)), false);
+    dci_bump_async_template_parts_cache_version();
 }
 add_action('save_post', 'dci_bump_async_template_parts_cache_version');
 add_action('deleted_post', 'dci_bump_async_template_parts_cache_version');
 add_action('created_term', 'dci_bump_async_template_parts_cache_version');
 add_action('edited_term', 'dci_bump_async_template_parts_cache_version');
 add_action('delete_term', 'dci_bump_async_template_parts_cache_version');
-add_action('added_option', 'dci_bump_async_template_parts_cache_version');
-add_action('updated_option', 'dci_bump_async_template_parts_cache_version');
-add_action('deleted_option', 'dci_bump_async_template_parts_cache_version');
+add_action('added_option', 'dci_maybe_bump_async_template_parts_cache_version_on_option');
+add_action('updated_option', 'dci_maybe_bump_async_template_parts_cache_version_on_option');
+add_action('deleted_option', 'dci_maybe_bump_async_template_parts_cache_version_on_option');
 
 function dci_async_template_parts_cache_key($template_key, $page_id, $term_id, $taxonomy, $query_string, $current_url = '') {
     return 'dci_async_tpl_' . md5(wp_json_encode(array(
@@ -373,8 +390,15 @@ function dci_ensure_feed_rss_page() {
         return;
     }
 
+    $cached_page_id = absint(get_option('dci_feed_rss_page_id', 0));
+    if ($cached_page_id && get_post_status($cached_page_id)) {
+        return;
+    }
+
     $page = get_page_by_path('feed-rss');
     if ($page instanceof WP_Post) {
+        update_option('dci_feed_rss_page_id', $page->ID, false);
+
         if (get_post_meta($page->ID, '_dci_auto_feed_rss_page', true) === '1' && $page->post_content !== dci_get_feed_rss_page_content()) {
             wp_update_post(array(
                 'ID' => $page->ID,
@@ -397,6 +421,7 @@ function dci_ensure_feed_rss_page() {
 
     if (!is_wp_error($page_id)) {
         update_post_meta($page_id, '_dci_auto_feed_rss_page', '1');
+        update_option('dci_feed_rss_page_id', $page_id, false);
     }
 }
 add_action('init', 'dci_ensure_feed_rss_page', 20);
@@ -645,7 +670,11 @@ function get_parent_template () {
 function getFileSizeAndFormat($url) {
     $percorso = parse_url($url);
     $percorso = isset($percorso["path"]) ? substr($percorso["path"], 0, -strlen(pathinfo($url, PATHINFO_BASENAME))) : '';
-    $response = wp_remote_head($url);
+    $response = wp_remote_head($url, array(
+        'timeout' => 4,
+        'redirection' => 2,
+        'reject_unsafe_urls' => true,
+    ));
 
     if (is_wp_error($response)) {
         return 'Errore nel recupero delle informazioni del file';

--- a/template-parts/prenotazione/content.php
+++ b/template-parts/prenotazione/content.php
@@ -1,7 +1,14 @@
 <?php
     $uffici = get_posts(array(
         'posts_per_page' => -1,
+        'fields' => 'ids',
+        'post_status' => 'publish',
         'post_type' => 'unita_organizzativa',
+        'orderby' => 'post_title',
+        'order' => 'ASC',
+        'no_found_rows' => true,
+        'ignore_sticky_posts' => true,
+        'update_post_term_cache' => false,
         'meta_query' => array(
             'relation' => 'AND',
             array(

--- a/template-parts/segnalazione/content.php
+++ b/template-parts/segnalazione/content.php
@@ -5,11 +5,6 @@
     $privacy_url = dci_get_template_page_url('page-templates/privacy.php') ?: home_url('/page-templates/privacy');
     $area_riservata_url = dci_get_option('area_riservata') ?: wp_login_url();
 
-    $uffici = get_posts(array(
-        'posts_per_page' => -1,
-        'post_type' => 'unita_organizzativa'
-    ));
-
     $luoghi = get_posts(array(
         'posts_per_page' => 300,
         'fields' => 'ids',

--- a/template-parts/servizio/categorie.php
+++ b/template-parts/servizio/categorie.php
@@ -23,18 +23,6 @@ if($mostra_categiorie_servizi=="true"){
         <h2 class="title-xxlarge mb-4">Esplora per categoria</h2>
         <div class="row g-4">
             <?php foreach ($categorie_servizio_names as $categoria_servizio_name) {
-                $args = array(
-                    'post_type' => 'servizio',
-                    'posts_per_page' => -1,
-                    'tax_query' => array(
-                        array(
-                            'taxonomy' => 'categorie_servizio',
-                            'field' => 'name',
-                            'terms' => $categoria_servizio_name,
-                        ),
-                    ),
-                );
-                $servizi = get_posts($args);
                 $categoria = get_term_by('name', $categoria_servizio_name, 'categorie_servizio');
                 $url = get_term_link($categoria->term_id, 'categorie_servizio');
             ?>


### PR DESCRIPTION
### Motivation
- Reduce unnecessary cache version bumps caused by unrelated option changes and make cache invalidation more targeted.
- Avoid repeated DB lookups for the auto-generated "Feed RSS" page by caching its post ID and skip recreation when valid.
- Improve robustness and performance of remote/head and post queries by adding timeouts, limiting fields, and disabling expensive query parts.

### Description
- Reworked cache bumping: simplified `dci_bump_async_template_parts_cache_version()` to only update the option, and added `dci_maybe_bump_async_template_parts_cache_version_on_option()` to only trigger bumps for a white-listed set of option names, then wired that function to the `added_option`, `updated_option`, and `deleted_option` hooks.
- Added caching for the feed page by storing `dci_feed_rss_page_id` and short-circuiting `dci_ensure_feed_rss_page()` when the cached post ID exists and the post status is valid, and save the option when creating or finding the page.
- Hardened remote head requests in `getFileSizeAndFormat()` by adding `timeout`, `redirection`, and `reject_unsafe_urls` parameters to `wp_remote_head()` and preserved WP error handling.
- Optimized several template parts queries by requesting only `ids` and adding query performance flags (`post_status`, `orderby`, `order`, `no_found_rows`, `ignore_sticky_posts`, `update_post_term_cache`) and removed unused or heavy per-category post queries in `template-parts/servizio/categorie.php` and an unused `$uffici` fetch in `template-parts/segnalazione/content.php`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd038ec848332a536b35d07917d72)