### PR TITLE
File handling refactor, selective cache bumping, and back-to-top color sync

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -136,6 +136,36 @@ if ($is_external_only && function_exists('dci_get_external_footer_payload')) {
     display: none !important;
   }
 }
+
+:root {
+  --dci-back-to-top-bg: #17324d;
+}
+
+.back-to-top,
+.back-to-top.back-to-top-small,
+.back-to-top.back-to-top-show {
+  background: var(--dci-back-to-top-bg) !important;
+  background-color: var(--dci-back-to-top-bg) !important;
+  color: #ffffff !important;
+}
+
+.back-to-top:hover,
+.back-to-top:focus {
+  background: var(--dci-back-to-top-bg) !important;
+  background-color: var(--dci-back-to-top-bg) !important;
+}
+
+.back-to-top .icon,
+.back-to-top .icon-light {
+  color: #ffffff !important;
+  fill: #ffffff !important;
+}
+
+.back-to-top .icon use,
+.back-to-top .icon-light use {
+  color: #ffffff !important;
+  fill: currentColor !important;
+}
 </style>
 <section class="cookiebar fade" aria-label="Gestione dei cookies" aria-live="polite">
   <p><strong class="cookiebar-title">Cookies</strong> Si usano i cookies e altre tecniche di tracciamento per migliorare la tua esperienza di navigazione nel nostro sito, per mostrarti contenuti personalizzati e annunci mirati, per analizzare il traffico sul nostro sito, e per capire da dove arrivano i nostri visitatori.
@@ -148,11 +178,69 @@ if ($is_external_only && function_exists('dci_get_external_footer_payload')) {
 </section>
 
 
-<div id="backToTop" data-bs-toggle="backtotop" class="back-to-top back-to-top-show back-to-top-show" style="overflow-hidden; cursor: pointer; box-shadow: 0 4px 8px rgba(0,0,0,0.2); background-color: white; transition: background-color 0.3s;">
-  <svg class="icon">
+<div id="backToTop" data-bs-toggle="backtotop" class="back-to-top back-to-top-show back-to-top-show" style="overflow-hidden; cursor: pointer; box-shadow: 0 4px 8px rgba(0,0,0,0.2); transition: background-color 0.3s;">
+  <svg class="icon icon-light" aria-label="Torna a inizio pagina">
     <use href="#it-collapse"></use>
   </svg>
 </div>
+<script>
+(function() {
+  function isSolidColor(color) {
+    if (!color || color === 'transparent') {
+      return false;
+    }
+
+    var rgbaMatch = color.match(/^rgba?\(([^)]+)\)$/);
+    if (!rgbaMatch) {
+      return true;
+    }
+
+    var parts = rgbaMatch[1].split(',').map(function(part) {
+      return part.trim();
+    });
+
+    return parts.length < 4 || parseFloat(parts[3]) > 0;
+  }
+
+  function getHeaderColor() {
+    var selectors = [
+      '.it-header-navbar-wrapper',
+      '.it-header-center-wrapper',
+      '.it-header-wrapper'
+    ];
+
+    for (var i = 0; i < selectors.length; i++) {
+      var element = document.querySelector(selectors[i]);
+
+      while (element) {
+        var color = window.getComputedStyle(element).backgroundColor;
+        if (isSolidColor(color)) {
+          return color;
+        }
+
+        element = element.parentElement;
+      }
+    }
+
+    return '';
+  }
+
+  function syncBackToTopColor() {
+    var color = getHeaderColor();
+    if (color) {
+      document.documentElement.style.setProperty('--dci-back-to-top-bg', color);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', syncBackToTopColor);
+  } else {
+    syncBackToTopColor();
+  }
+
+  window.addEventListener('load', syncBackToTopColor);
+}());
+</script>
 
 <footer class="it-footer" id="footer">
     <div class="it-footer-main">

--- a/functions.php
+++ b/functions.php
@@ -170,32 +170,49 @@ function dci_async_template_parts_cache_version() {
     return $version;
 }
 
-function dci_bump_async_template_parts_cache_version($option = '') {
-    $ignored_options = array(
-        'dci_async_template_parts_cache_version',
-        'wpc_home_count',
-        'wpc_home_daily_counts',
-        'dci_calendar_cache_version',
+function dci_bump_async_template_parts_cache_version() {
+    update_option('dci_async_template_parts_cache_version', str_replace('.', '', (string) microtime(true)), false);
+}
+
+function dci_maybe_bump_async_template_parts_cache_version_on_option($option) {
+    $cache_sensitive_options = array(
+        'accesso_rapido',
+        'amministrazione',
+        'argomenti',
+        'assistenza',
+        'dci_options',
+        'documenti',
+        'footer',
+        'Galleria',
+        'galleria',
+        'home_messages',
+        'homepage',
+        'link_utili',
+        'luoghi',
+        'multimedia',
+        'novita',
+        'ricerca',
+        'servizi',
+        'socials',
+        'strip_home',
+        'trasparenza',
+        'vivi',
     );
 
-    if (is_string($option) && (
-        in_array($option, $ignored_options, true)
-        || strpos($option, '_transient_') === 0
-        || strpos($option, '_site_transient_') === 0
-    )) {
+    if (!in_array((string) $option, $cache_sensitive_options, true)) {
         return;
     }
 
-    update_option('dci_async_template_parts_cache_version', str_replace('.', '', (string) microtime(true)), false);
+    dci_bump_async_template_parts_cache_version();
 }
 add_action('save_post', 'dci_bump_async_template_parts_cache_version');
 add_action('deleted_post', 'dci_bump_async_template_parts_cache_version');
 add_action('created_term', 'dci_bump_async_template_parts_cache_version');
 add_action('edited_term', 'dci_bump_async_template_parts_cache_version');
 add_action('delete_term', 'dci_bump_async_template_parts_cache_version');
-add_action('added_option', 'dci_bump_async_template_parts_cache_version');
-add_action('updated_option', 'dci_bump_async_template_parts_cache_version');
-add_action('deleted_option', 'dci_bump_async_template_parts_cache_version');
+add_action('added_option', 'dci_maybe_bump_async_template_parts_cache_version_on_option');
+add_action('updated_option', 'dci_maybe_bump_async_template_parts_cache_version_on_option');
+add_action('deleted_option', 'dci_maybe_bump_async_template_parts_cache_version_on_option');
 
 function dci_async_template_parts_cache_key($template_key, $page_id, $term_id, $taxonomy, $query_string, $current_url = '') {
     return 'dci_async_tpl_' . md5(wp_json_encode(array(
@@ -373,8 +390,15 @@ function dci_ensure_feed_rss_page() {
         return;
     }
 
+    $cached_page_id = absint(get_option('dci_feed_rss_page_id', 0));
+    if ($cached_page_id && get_post_status($cached_page_id)) {
+        return;
+    }
+
     $page = get_page_by_path('feed-rss');
     if ($page instanceof WP_Post) {
+        update_option('dci_feed_rss_page_id', $page->ID, false);
+
         if (get_post_meta($page->ID, '_dci_auto_feed_rss_page', true) === '1' && $page->post_content !== dci_get_feed_rss_page_content()) {
             wp_update_post(array(
                 'ID' => $page->ID,
@@ -397,6 +421,7 @@ function dci_ensure_feed_rss_page() {
 
     if (!is_wp_error($page_id)) {
         update_post_meta($page_id, '_dci_auto_feed_rss_page', '1');
+        update_option('dci_feed_rss_page_id', $page_id, false);
     }
 }
 add_action('init', 'dci_ensure_feed_rss_page', 20);
@@ -642,26 +667,81 @@ function get_parent_template () {
 
 
  // Restituisce il formato e le dimensioni di un allegato
-function getFileSizeAndFormat($url) {
-    $percorso = parse_url($url);
-    $percorso = isset($percorso["path"]) ? substr($percorso["path"], 0, -strlen(pathinfo($url, PATHINFO_BASENAME))) : '';
-    $response = wp_remote_head($url);
+if (!function_exists('dci_format_file_size')) {
+    function dci_format_file_size($bytes) {
+        $bytes = absint($bytes);
 
-    if (is_wp_error($response)) {
-        return 'Errore nel recupero delle informazioni del file';
+        if ($bytes >= 1073741824) {
+            return number_format_i18n($bytes / 1073741824, 2) . ' Gb';
+        }
+
+        if ($bytes >= 1048576) {
+            return number_format_i18n($bytes / 1048576, 2) . ' Mb';
+        }
+
+        if ($bytes >= 1024) {
+            return number_format_i18n($bytes / 1024, 2) . ' Kb';
+        }
+
+        return $bytes . ' byte';
+    }
+}
+
+function getFileSizeAndFormat($url) {
+    $url = trim((string) $url);
+    if ($url === '') {
+        return 'FILE';
     }
 
-    $headers = wp_remote_retrieve_headers($response);
-    $content_length = isset($headers['content-length']) ? intval($headers['content-length']) : 0;
+    if (is_numeric($url)) {
+        $attachment_url = wp_get_attachment_url((int) $url);
+        if ($attachment_url) {
+            $url = $attachment_url;
+        }
+    }
 
-    $base = log($content_length, 1024);
-    $suffixes = array('', 'Kb', 'Mb', 'Gb', 'Tb');
-    $size_formatted = round(pow(1024, $base - floor($base)), 2) . ' ' . $suffixes[floor($base)];
+    $filetype = wp_check_filetype($url);
+    $file_format = !empty($filetype['ext']) ? strtoupper($filetype['ext']) : strtoupper(pathinfo((string) wp_parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION));
+    if ($file_format === '') {
+        $file_format = 'FILE';
+    }
 
-    $info_file = pathinfo($url);
-    $file_format = strtoupper(isset($info_file['extension']) ? $info_file['extension'] : '');
+    $attachment_id = attachment_url_to_postid($url);
+    if ($attachment_id) {
+        $local_file = get_attached_file($attachment_id);
+        if ($local_file && file_exists($local_file) && is_readable($local_file)) {
+            $local_size = filesize($local_file);
+            if ($local_size !== false && $local_size > 0) {
+                return $file_format . ' ' . dci_format_file_size($local_size);
+            }
+        }
+    }
 
-    return $file_format . ' ' . $size_formatted;
+    $cache_key = 'dci_file_info_' . md5($url);
+    $cached = get_transient($cache_key);
+    if (is_array($cached) && isset($cached['label'])) {
+        return (string) $cached['label'];
+    }
+
+    $label = $file_format;
+    $response = wp_remote_head($url, array(
+        'timeout' => 4,
+        'redirection' => 2,
+        'reject_unsafe_urls' => true,
+    ));
+
+    if (!is_wp_error($response)) {
+        $headers = wp_remote_retrieve_headers($response);
+        $content_length = isset($headers['content-length']) ? absint($headers['content-length']) : 0;
+
+        if ($content_length > 0) {
+            $label = $file_format . ' ' . dci_format_file_size($content_length);
+        }
+    }
+
+    set_transient($cache_key, array('label' => $label), 12 * HOUR_IN_SECONDS);
+
+    return $label;
 }
 
 

--- a/single-documento_pubblico.php
+++ b/single-documento_pubblico.php
@@ -252,9 +252,26 @@ get_header();
                                 // Cicla gli allegati (multipli o singolo convertito)
                                 if (!empty($file_documento)) {
                                     foreach ($file_documento as $file_url) {
-                                        $documento_id = attachment_url_to_postid($file_url);
-                                        $documento = get_post($documento_id);
-                                        $titolo = $documento ? $documento->post_title : basename($file_url);
+                                        if (is_array($file_url)) {
+                                            continue;
+                                        }
+
+                                        $file_url = trim((string) $file_url);
+                                        $documento_id = is_numeric($file_url) ? absint($file_url) : attachment_url_to_postid($file_url);
+
+                                        if ($documento_id && is_numeric($file_url)) {
+                                            $attachment_url = wp_get_attachment_url($documento_id);
+                                            if ($attachment_url) {
+                                                $file_url = $attachment_url;
+                                            }
+                                        }
+
+                                        if ($file_url === '') {
+                                            continue;
+                                        }
+
+                                        $documento = $documento_id ? get_post($documento_id) : null;
+                                        $titolo = $documento ? $documento->post_title : basename((string) wp_parse_url($file_url, PHP_URL_PATH));
                                         ?>
                                         <div class="card card-teaser shadow-sm p-4 mt-3 rounded border border-light flex-nowrap">
                                             <svg class="icon" aria-hidden="true">
@@ -266,7 +283,7 @@ get_header();
                                                         aria-label="Scarica il documento <?php echo esc_attr($titolo); ?>"
                                                         title="Scarica il documento <?php echo esc_attr($titolo); ?>">
                                                         <?php echo esc_html($titolo); ?>
-                                                        (<?php echo getFileSizeAndFormat($file_url); ?>)
+                                                        (<?php echo esc_html(getFileSizeAndFormat($file_url)); ?>)
                                                     </a>
                                                 </h5>
                                             </div>

--- a/template-parts/documento/file.php
+++ b/template-parts/documento/file.php
@@ -2,45 +2,36 @@
 global $nomefile, $idfile;
 
 $icon = "svg-documents";
-if(substr($nomefile, -3) == "pdf")
-	$icon = "it-pdf-document";
-if(substr($nomefile, -3) == "doc")
-	$icon = "svg-doc-document";
-if(substr($nomefile, -4) == "docx")
-	$icon = "svg-doc-document";
-if(substr($nomefile, -3) == "xml")
-	$icon = "svg-xml-document";
-
-$ext = substr($nomefile, -4);
+if (substr((string) $nomefile, -3) == "pdf") {
+    $icon = "it-pdf-document";
+}
+if (substr((string) $nomefile, -3) == "doc") {
+    $icon = "svg-doc-document";
+}
+if (substr((string) $nomefile, -4) == "docx") {
+    $icon = "svg-doc-document";
+}
+if (substr((string) $nomefile, -3) == "xml") {
+    $icon = "svg-xml-document";
+}
 
 $attach = get_post($idfile);
 $filetocheck = get_attached_file($idfile);
-
-$filesize = filesize($filetocheck);
-$fulltype = mime_content_type($filetocheck);
-$arrtype = explode("/", $fulltype);
-$arrtype_more = explode(".", $arrtype[count($arrtype)-1]);
-if(is_array($arrtype_more)) {
-    $arrtype = $arrtype_more;
-}
-$type = "file";
-if(is_array($arrtype))
-    $type = $arrtype[count($arrtype)-1];
-
-$ptitle = $attach->post_title;
-if(trim($ptitle) == ""){
-    $ptitle = str_replace("-", " ", basename($filetocheck, $ext));
-    $ptitle = str_replace("_", " ", $ptitle);
+$file_url = wp_get_attachment_url($idfile);
+$file_info = $file_url ? getFileSizeAndFormat($file_url) : 'FILE';
+$ptitle = $attach ? $attach->post_title : '';
+if (trim($ptitle) == "") {
+    $filename = $filetocheck ? basename($filetocheck) : (string) $nomefile;
+    $ptitle = str_replace(array("-", "_"), " ", pathinfo($filename, PATHINFO_FILENAME));
 }
 ?>
-	<div class="card card-bg card-icon rounded">
-		<div class="card-body">
-			<svg class="icon <?php echo $icon; ?>"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#<?php echo $icon; ?>"></use></svg>
-			<div class="card-icon-content">
-				<p><strong><a target="_blank" href="<?php echo $attach->guid; ?>"><?php echo $ptitle; ?></a></strong></p>
-				<small><?php echo $type; ?> - <?php echo intval($filesize/1024); ?> kb</small>
-			</div><!-- /card-icon-content -->
-		</div><!-- /card-body -->
-	</div><!-- /card card-bg card-icon rounded -->
+    <div class="card card-bg card-icon rounded">
+        <div class="card-body">
+            <svg class="icon <?php echo esc_attr($icon); ?>"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#<?php echo esc_attr($icon); ?>"></use></svg>
+            <div class="card-icon-content">
+                <p><strong><a target="_blank" href="<?php echo esc_url($file_url); ?>"><?php echo esc_html($ptitle); ?></a></strong></p>
+                <small><?php echo esc_html($file_info); ?></small>
+            </div><!-- /card-icon-content -->
+        </div><!-- /card-body -->
+    </div><!-- /card card-bg card-icon rounded -->
 <?php
-

--- a/template-parts/prenotazione/content.php
+++ b/template-parts/prenotazione/content.php
@@ -1,7 +1,14 @@
 <?php
     $uffici = get_posts(array(
         'posts_per_page' => -1,
+        'fields' => 'ids',
+        'post_status' => 'publish',
         'post_type' => 'unita_organizzativa',
+        'orderby' => 'post_title',
+        'order' => 'ASC',
+        'no_found_rows' => true,
+        'ignore_sticky_posts' => true,
+        'update_post_term_cache' => false,
         'meta_query' => array(
             'relation' => 'AND',
             array(

--- a/template-parts/segnalazione/content.php
+++ b/template-parts/segnalazione/content.php
@@ -5,11 +5,6 @@
     $privacy_url = dci_get_template_page_url('page-templates/privacy.php') ?: home_url('/page-templates/privacy');
     $area_riservata_url = dci_get_option('area_riservata') ?: wp_login_url();
 
-    $uffici = get_posts(array(
-        'posts_per_page' => -1,
-        'post_type' => 'unita_organizzativa'
-    ));
-
     $luoghi = get_posts(array(
         'posts_per_page' => 300,
         'fields' => 'ids',

--- a/template-parts/servizio/categorie.php
+++ b/template-parts/servizio/categorie.php
@@ -23,18 +23,6 @@ if($mostra_categiorie_servizi=="true"){
         <h2 class="title-xxlarge mb-4">Esplora per categoria</h2>
         <div class="row g-4">
             <?php foreach ($categorie_servizio_names as $categoria_servizio_name) {
-                $args = array(
-                    'post_type' => 'servizio',
-                    'posts_per_page' => -1,
-                    'tax_query' => array(
-                        array(
-                            'taxonomy' => 'categorie_servizio',
-                            'field' => 'name',
-                            'terms' => $categoria_servizio_name,
-                        ),
-                    ),
-                );
-                $servizi = get_posts($args);
                 $categoria = get_term_by('name', $categoria_servizio_name, 'categorie_servizio');
                 $url = get_term_link($categoria->term_id, 'categorie_servizio');
             ?>

--- a/template-parts/single/attachment.php
+++ b/template-parts/single/attachment.php
@@ -1,48 +1,17 @@
 <?php
 global $file_url;
 
-function formatSizeUnits($bytes)
-{
-    if ($bytes >= 1073741824)
-    {
-        $bytes = number_format($bytes / 1073741824, 2) . ' GB';
-    }
-    elseif ($bytes >= 1048576)
-    {
-        $bytes = number_format($bytes / 1048576, 2) . ' MB';
-    }
-    elseif ($bytes >= 1024)
-    {
-        $bytes = number_format($bytes / 1024, 2) . ' kB';
-    }
-    elseif ($bytes > 1)
-    {
-        $bytes = $bytes . ' bytes';
-    }
-    elseif ($bytes == 1)
-    {
-        $bytes = $bytes . ' byte';
-    }
-    else
-    {
-        $bytes = '0 bytes';
-    }
-
-    return $bytes;
-}
-
-$attachment_id = attachment_url_to_postid($file_url) ;
-$size = formatSizeUnits( filesize( get_attached_file( $attachment_id ) ) );
-$extension = strtoupper( wp_check_filetype($file_url)['ext'] );
+$file_url = trim((string) $file_url);
+$file_info = getFileSizeAndFormat($file_url);
 ?>
 
 <div class="cmp-icon-link">
-    <a class="list-item icon-left d-inline-block" href="<?php echo $file_url; ?>" aria-label="Scarica Termini e condizioni di servizio (<?php echo $extension.' '.$size; ?>)" data-element="service-file">
+    <a class="list-item icon-left d-inline-block" href="<?php echo esc_url($file_url); ?>" aria-label="Scarica Termini e condizioni di servizio (<?php echo esc_attr($file_info); ?>)" data-element="service-file">
     <span class="list-item-title-icon-wrapper">
         <svg class="icon icon-primary icon-sm me-1" aria-hidden="true">
         <use href="#it-clip"></use>
         </svg>
-        <span class="list-item t-primary">Termini e condizioni di servizio (<?php echo $extension.' '.$size; ?>)</span>
+        <span class="list-item t-primary">Termini e condizioni di servizio (<?php echo esc_html($file_info); ?>)</span>
     </span>
     </a>
 </div>


### PR DESCRIPTION
### Motivation
- Provide reliable file size/format labels for attachments and external files, support numeric attachment IDs, and cache results to reduce remote HEAD requests.
- Avoid unnecessary invalidation of async template part caches by bumping cache version only for relevant option changes.
- Make the back-to-top control match the header color dynamically and clean up markup/ARIA.
- Improve template performance by reducing heavy post queries and hard-to-maintain per-category queries.

### Description
- Added a CSS variable and a small script in `footer.php` to detect the header background and sync `--dci-back-to-top-bg`, removed the inline white background and added `aria-label` to the back-to-top icon.
- Introduced `dci_format_file_size()` and reworked `getFileSizeAndFormat()` in `functions.php` to support numeric IDs, attachments, local filesize checks, remote `HEAD` fallback, transient caching, and safer parsing of file formats.
- Replaced the previous global cache-bump function with `dci_bump_async_template_parts_cache_version()` and `dci_maybe_bump_async_template_parts_cache_version_on_option()` to only bump the async-template cache for a white-listed set of options, and wired these to option hooks.
- Cache the resolved Feed RSS page id with `dci_feed_rss_page_id` and avoid regenerating the page when already present.
- Updated templates (`single-documento_pubblico.php`, `template-parts/documento/file.php`, `template-parts/single/attachment.php`) to use the new file info helpers, accept arrays and numeric IDs, trim and validate inputs, and add proper escaping for URLs and text.
- Optimized several queries by requesting only IDs and adding ordering and `no_found_rows`/cache-related flags in `template-parts/prenotazione/content.php`, removed an unused heavy `get_posts` call in the segnalazione template, and simplified category listing in `template-parts/servizio/categorie.php` to avoid per-category `get_posts` loops.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd038ec848332a536b35d07917d72)