### PR TITLE
Add retryable async template loading, external header API, file size handling and footer signature logic

### DIFF
--- a/assets/js/async-template-parts.js
+++ b/assets/js/async-template-parts.js
@@ -3,27 +3,48 @@
 
   var settings = window.dciAsyncTemplateParts || {};
 
-  function fallbackToSync() {
-    var paramName = settings.disableParam || 'dci_disable_async';
-    var currentUrl;
-    var fallbackUrl;
+  function getLoaderMarkup(message) {
+    return '<div class="container py-5"><div class="dci-async-loader" aria-hidden="true"><span class="dci-async-loader__spinner"></span><span class="dci-async-loader__line dci-async-loader__line--long"></span><span class="dci-async-loader__line"></span></div><span class="visually-hidden">' + message + '</span></div>';
+  }
 
-    try {
-      currentUrl = new URL(window.location.href);
-      if (currentUrl.searchParams.get(paramName) === '1') {
-        return false;
-      }
-      currentUrl.searchParams.set(paramName, '1');
-      fallbackUrl = currentUrl.toString();
-    } catch (error) {
-      if (window.location.search.indexOf(paramName + '=1') !== -1) {
-        return false;
-      }
-      fallbackUrl = window.location.href + (window.location.search ? '&' : '?') + encodeURIComponent(paramName) + '=1';
+  function restartTemplateRetryCycle(placeholder) {
+    placeholder.removeAttribute('data-retry-count');
+    placeholder.classList.remove('dci-async-template--error');
+    placeholder.setAttribute('aria-busy', 'true');
+    placeholder.innerHTML = getLoaderMarkup('Nuovo tentativo di caricamento della sezione');
+    loadTemplate(placeholder);
+  }
+
+  function showTemplateRetryButton(placeholder) {
+    placeholder.setAttribute('aria-busy', 'false');
+    placeholder.classList.add('dci-async-template--error');
+    placeholder.innerHTML = '<div class="container py-5"><p class="mb-2">Non è stato possibile caricare questa sezione.</p><button class="btn btn-primary btn-sm" type="button">Riprova</button></div>';
+    var retry = placeholder.querySelector('button');
+    if (retry) {
+      retry.addEventListener('click', function () {
+        restartTemplateRetryCycle(placeholder);
+      });
+    }
+  }
+
+  function scheduleTemplateRetry(placeholder) {
+    var retryCount = parseInt(placeholder.getAttribute('data-retry-count') || '0', 10) + 1;
+    var maxRetries = parseInt(settings.maxRetries, 10) || 4;
+    var retryDelay = Math.min(20000, 2000 * retryCount);
+
+    if (retryCount > maxRetries) {
+      showTemplateRetryButton(placeholder);
+      return;
     }
 
-    window.location.replace(fallbackUrl);
-    return true;
+    placeholder.setAttribute('data-retry-count', retryCount);
+    placeholder.setAttribute('aria-busy', 'true');
+    placeholder.classList.remove('dci-async-template--error');
+    placeholder.innerHTML = getLoaderMarkup('Nuovo tentativo di caricamento della sezione');
+
+    window.setTimeout(function () {
+      loadTemplate(placeholder);
+    }, retryDelay);
   }
 
   function getAjaxUrl() {
@@ -43,7 +64,6 @@
   }
 
   if (!settings.ajaxurl || !window.fetch) {
-    fallbackToSync();
     return;
   }
 
@@ -139,6 +159,7 @@
           throw new Error('Risposta non valida');
         }
 
+        placeholder.removeAttribute('data-retry-count');
         var wrapper = document.createElement('div');
         wrapper.innerHTML = payload.data.html;
         wrapper.className = 'dci-async-template__content';
@@ -151,19 +172,7 @@
           window.clearTimeout(timeoutId);
         }
 
-        if (fallbackToSync()) {
-          return;
-        }
-
-        placeholder.setAttribute('aria-busy', 'false');
-        placeholder.classList.add('dci-async-template--error');
-        placeholder.innerHTML = '<div class="container py-5"><p class="mb-2">Non è stato possibile caricare questa sezione.</p><button class="btn btn-primary btn-sm" type="button">Riprova</button></div>';
-        var retry = placeholder.querySelector('button');
-        if (retry) {
-          retry.addEventListener('click', function () {
-            window.location.reload();
-          });
-        }
+        scheduleTemplateRetry(placeholder);
       });
   }
 

--- a/footer.php
+++ b/footer.php
@@ -148,9 +148,9 @@ if ($is_external_only && function_exists('dci_get_external_footer_payload')) {
 </section>
 
 
-<div id="backToTop" data-bs-toggle="backtotop" class="back-to-top back-to-top-show back-to-top-show" style="overflow-hidden; cursor: pointer; box-shadow: 0 4px 8px rgba(0,0,0,0.2); background-color: white; transition: background-color 0.3s;">
-  <svg class="icon">
-    <use href="#it-collapse"></use>
+<div id="backToTop" data-bs-toggle="backtotop" class="back-to-top back-to-top-show" style="overflow-hidden; cursor: pointer; box-shadow: 0 4px 8px rgba(0,0,0,0.2); background-color: white; transition: background-color 0.3s;">
+  <svg class="icon" aria-label="Torna a inizio pagina" style="color: #000000; fill: #000000;">
+    <use href="#it-collapse" style="color: #000000; fill: #000000;"></use>
   </svg>
 </div>
 
@@ -391,16 +391,10 @@ if ($is_external_only && function_exists('dci_get_external_footer_payload')) {
 	                            <li class="list-inline-item d-flex">
 	                                <small>  © <?php echo dci_get_option("nome_comune"); ?>                                        
 					 <?php
-						$firma_nostra = dci_get_option("firma_nostra");
-
-						if ($firma_nostra === 'false' || $firma_nostra === false) : ?>
-						    &nbsp;&nbsp;-&nbsp;&nbsp;Sviluppato da 
-						        <a class="text-primary" style="text-decoration:none;" target="_blank" href="https://www.p-service.it/" title="Point Service S.r.l" aria-label="Point Service S.r.l" aria-labelledby="footerCompanyLabel">
-						            <span id="footerCompanyLabel" style="color: #fff">
-						                &nbsp;Point Service S.r.l
-						            </span>
-						        </a>  						   
-						<?php endif; ?>
+						if (function_exists('dci_get_footer_signature_html')) {
+							echo dci_get_footer_signature_html();
+						}
+					?>
 				      </small>
 	                            </li>
                         </ul>

--- a/functions.php
+++ b/functions.php
@@ -170,32 +170,49 @@ function dci_async_template_parts_cache_version() {
     return $version;
 }
 
-function dci_bump_async_template_parts_cache_version($option = '') {
-    $ignored_options = array(
-        'dci_async_template_parts_cache_version',
-        'wpc_home_count',
-        'wpc_home_daily_counts',
-        'dci_calendar_cache_version',
+function dci_bump_async_template_parts_cache_version() {
+    update_option('dci_async_template_parts_cache_version', str_replace('.', '', (string) microtime(true)), false);
+}
+
+function dci_maybe_bump_async_template_parts_cache_version_on_option($option) {
+    $cache_sensitive_options = array(
+        'accesso_rapido',
+        'amministrazione',
+        'argomenti',
+        'assistenza',
+        'dci_options',
+        'documenti',
+        'footer',
+        'Galleria',
+        'galleria',
+        'home_messages',
+        'homepage',
+        'link_utili',
+        'luoghi',
+        'multimedia',
+        'novita',
+        'ricerca',
+        'servizi',
+        'socials',
+        'strip_home',
+        'trasparenza',
+        'vivi',
     );
 
-    if (is_string($option) && (
-        in_array($option, $ignored_options, true)
-        || strpos($option, '_transient_') === 0
-        || strpos($option, '_site_transient_') === 0
-    )) {
+    if (!in_array((string) $option, $cache_sensitive_options, true)) {
         return;
     }
 
-    update_option('dci_async_template_parts_cache_version', str_replace('.', '', (string) microtime(true)), false);
+    dci_bump_async_template_parts_cache_version();
 }
 add_action('save_post', 'dci_bump_async_template_parts_cache_version');
 add_action('deleted_post', 'dci_bump_async_template_parts_cache_version');
 add_action('created_term', 'dci_bump_async_template_parts_cache_version');
 add_action('edited_term', 'dci_bump_async_template_parts_cache_version');
 add_action('delete_term', 'dci_bump_async_template_parts_cache_version');
-add_action('added_option', 'dci_bump_async_template_parts_cache_version');
-add_action('updated_option', 'dci_bump_async_template_parts_cache_version');
-add_action('deleted_option', 'dci_bump_async_template_parts_cache_version');
+add_action('added_option', 'dci_maybe_bump_async_template_parts_cache_version_on_option');
+add_action('updated_option', 'dci_maybe_bump_async_template_parts_cache_version_on_option');
+add_action('deleted_option', 'dci_maybe_bump_async_template_parts_cache_version_on_option');
 
 function dci_async_template_parts_cache_key($template_key, $page_id, $term_id, $taxonomy, $query_string, $current_url = '') {
     return 'dci_async_tpl_' . md5(wp_json_encode(array(
@@ -373,8 +390,15 @@ function dci_ensure_feed_rss_page() {
         return;
     }
 
+    $cached_page_id = absint(get_option('dci_feed_rss_page_id', 0));
+    if ($cached_page_id && get_post_status($cached_page_id)) {
+        return;
+    }
+
     $page = get_page_by_path('feed-rss');
     if ($page instanceof WP_Post) {
+        update_option('dci_feed_rss_page_id', $page->ID, false);
+
         if (get_post_meta($page->ID, '_dci_auto_feed_rss_page', true) === '1' && $page->post_content !== dci_get_feed_rss_page_content()) {
             wp_update_post(array(
                 'ID' => $page->ID,
@@ -397,6 +421,7 @@ function dci_ensure_feed_rss_page() {
 
     if (!is_wp_error($page_id)) {
         update_post_meta($page_id, '_dci_auto_feed_rss_page', '1');
+        update_option('dci_feed_rss_page_id', $page_id, false);
     }
 }
 add_action('init', 'dci_ensure_feed_rss_page', 20);
@@ -561,8 +586,8 @@ function dci_scripts() {
 	wp_localize_script( 'dci-async-template-parts', 'dciAsyncTemplateParts', array(
 		'ajaxurl' => admin_url( 'admin-ajax.php', 'relative' ),
 		'maxConcurrent' => 2,
-		'disableParam' => 'dci_disable_async',
-		'timeoutMs' => 15000,
+		'maxRetries' => 4,
+		'timeoutMs' => 20000,
 	) );
 	wp_script_add_data( 'dci-async-template-parts', 'defer', true );
 	wp_add_inline_script( 'dci-comuni', 'window.wpRestApi = "' . get_rest_url() . '"', 'before' );
@@ -642,26 +667,63 @@ function get_parent_template () {
 
 
  // Restituisce il formato e le dimensioni di un allegato
-function getFileSizeAndFormat($url) {
-    $percorso = parse_url($url);
-    $percorso = isset($percorso["path"]) ? substr($percorso["path"], 0, -strlen(pathinfo($url, PATHINFO_BASENAME))) : '';
-    $response = wp_remote_head($url);
+if (!function_exists('dci_format_file_size')) {
+    function dci_format_file_size($bytes) {
+        $bytes = absint($bytes);
 
-    if (is_wp_error($response)) {
-        return 'Errore nel recupero delle informazioni del file';
+        if ($bytes >= 1073741824) {
+            return number_format_i18n($bytes / 1073741824, 2) . ' Gb';
+        }
+
+        if ($bytes >= 1048576) {
+            return number_format_i18n($bytes / 1048576, 2) . ' Mb';
+        }
+
+        if ($bytes >= 1024) {
+            return number_format_i18n($bytes / 1024, 2) . ' Kb';
+        }
+
+        return $bytes . ' byte';
+    }
+}
+
+function getFileSizeAndFormat($url) {
+    $url = trim((string) $url);
+    if ($url === '') {
+        return 'FILE';
     }
 
-    $headers = wp_remote_retrieve_headers($response);
-    $content_length = isset($headers['content-length']) ? intval($headers['content-length']) : 0;
+    if (is_numeric($url)) {
+        $attachment_url = wp_get_attachment_url((int) $url);
+        if ($attachment_url) {
+            $url = $attachment_url;
+        }
+    }
 
-    $base = log($content_length, 1024);
-    $suffixes = array('', 'Kb', 'Mb', 'Gb', 'Tb');
-    $size_formatted = round(pow(1024, $base - floor($base)), 2) . ' ' . $suffixes[floor($base)];
+    $filetype = wp_check_filetype($url);
+    $file_format = !empty($filetype['ext']) ? strtoupper($filetype['ext']) : strtoupper(pathinfo((string) wp_parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION));
+    if ($file_format === '') {
+        $file_format = 'FILE';
+    }
 
-    $info_file = pathinfo($url);
-    $file_format = strtoupper(isset($info_file['extension']) ? $info_file['extension'] : '');
+    $url_host = wp_parse_url($url, PHP_URL_HOST);
+    $site_host = wp_parse_url(home_url('/'), PHP_URL_HOST);
+    $is_local_url = !$url_host || !$site_host || strtolower((string) $url_host) === strtolower((string) $site_host);
 
-    return $file_format . ' ' . $size_formatted;
+    if ($is_local_url) {
+        $attachment_id = attachment_url_to_postid($url);
+        if ($attachment_id) {
+            $local_file = get_attached_file($attachment_id);
+            if ($local_file && file_exists($local_file) && is_readable($local_file)) {
+                $local_size = filesize($local_file);
+                if ($local_size !== false && $local_size > 0) {
+                    return $file_format . ' ' . dci_format_file_size($local_size);
+                }
+            }
+        }
+    }
+
+    return $file_format;
 }
 
 

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -131,6 +131,31 @@ function dci_register_footer_export_route() {
 add_action('rest_api_init', 'dci_register_footer_export_route');
 
 /**
+ * Espone l'HTML dell'header per integrazioni esterne.
+ */
+function dci_register_header_export_route() {
+    register_rest_route('wp/v2', '/header/rendered/', array(
+        'methods' => 'GET',
+        'callback' => 'dci_get_rendered_header',
+        'permission_callback' => '__return_true',
+    ));
+}
+add_action('rest_api_init', 'dci_register_header_export_route');
+
+/**
+ * Restituisce il markup loader da mostrare mentre header/footer sono letti via API.
+ *
+ * @param string $label
+ * @return string
+ */
+function dci_get_external_fragment_loader_html($label = 'Caricamento contenuto') {
+    return '<div class="dci-api-fragment-loader" role="status" aria-live="polite">'
+        . '<span class="dci-api-fragment-loader__spinner" aria-hidden="true"></span>'
+        . '<span class="visually-hidden">' . esc_html($label) . '</span>'
+        . '</div>';
+}
+
+/**
  * Verifica valori booleani salvati dalle opzioni CMB2/radio del tema.
  *
  * @param mixed $value
@@ -167,6 +192,70 @@ function dci_should_fetch_external_footer() {
     return dci_is_truthy_option_value(dci_get_option('ck_richiama_footer_portale_principale', 'dci_options', 'false'));
 }
 
+
+/**
+ * Verifica se la firma Point Service deve essere visibile nel footer locale.
+ *
+ * @return bool
+ */
+function dci_should_show_footer_signature() {
+    return !dci_is_truthy_option_value(dci_get_option('firma_nostra'));
+}
+
+/**
+ * Restituisce la firma Point Service usata dal footer standard.
+ *
+ * @return string
+ */
+function dci_get_footer_signature_html() {
+    if (!dci_should_show_footer_signature()) {
+        return '';
+    }
+
+    return '&nbsp;&nbsp;-&nbsp;&nbsp;Sviluppato da '
+        . '<a class="text-primary" style="text-decoration:none;" target="_blank" href="https://www.p-service.it/" title="Point Service S.r.l" aria-label="Point Service S.r.l" aria-labelledby="footerCompanyLabel">'
+        . '<span id="footerCompanyLabel" style="color: #fff">'
+        . '&nbsp;Point Service S.r.l'
+        . '</span>'
+        . '</a>';
+}
+
+/**
+ * Applica la firma locale al footer recuperato via API quando il check locale lo richiede.
+ *
+ * @param string $html
+ * @return string
+ */
+function dci_apply_local_footer_signature($html) {
+    if (!is_string($html) || $html === '' || !dci_should_show_footer_signature()) {
+        return $html;
+    }
+
+    if (stripos($html, 'p-service.it') !== false || stripos($html, 'Point Service S.r.l') !== false) {
+        return $html;
+    }
+
+    $signature_html = dci_get_footer_signature_html();
+    if ($signature_html === '') {
+        return $html;
+    }
+
+    $pattern = '/(<small\b[^>]*>\s*©[\s\S]*?)(<\/small>)/i';
+    if (preg_match($pattern, $html)) {
+        return preg_replace($pattern, '$1' . $signature_html . '$2', $html, 1);
+    }
+
+    $fallback_html = '<div class="footer-bottom"><ul class="it-footer-small-prints-list list-inline mb-0 d-flex flex-column flex-md-row" style="float: right;">'
+        . '<li class="list-inline-item d-flex"><small>© ' . esc_html(dci_get_option('nome_comune')) . $signature_html . '</small></li>'
+        . '</ul></div>';
+
+    if (stripos($html, '</footer>') !== false) {
+        return preg_replace('/<\/footer>/i', $fallback_html . '</footer>', $html, 1);
+    }
+
+    return $html . $fallback_html;
+}
+
 /**
  * Stampa nel <head> locale le risorse recuperate dal portale principale, se abilitate.
  */
@@ -198,6 +287,7 @@ function dci_get_external_footer_payload() {
     $footer_cached = get_transient($footer_cache_key);
     if (is_array($footer_cached)) {
         if (!empty($footer_cached['html'])) {
+            $footer_cached['html'] = dci_apply_local_footer_signature($footer_cached['html']);
             return $footer_cached;
         }
         return null;
@@ -207,7 +297,11 @@ function dci_get_external_footer_payload() {
         $cache_key = 'dci_ext_footer_v2_' . md5(strtolower((string) $external_home) . '|' . home_url('/'));
         $cached_payload = get_transient($cache_key);
         if (is_array($cached_payload)) {
-            return !empty($cached_payload['html']) ? $cached_payload : null;
+            if (!empty($cached_payload['html'])) {
+                $cached_payload['html'] = dci_apply_local_footer_signature($cached_payload['html']);
+                return $cached_payload;
+            }
+            return null;
         }
 
         $current_home = trailingslashit(home_url('/'));
@@ -262,7 +356,9 @@ function dci_get_external_footer_payload() {
                     $payload['html'] = dci_absolutize_external_html_urls($payload['html'], $external_home);
                     $payload['source'] = $external_api;
                     $payload['attempted_sources'] = $attempted_sources;
+                    $payload['loading_html'] = dci_get_external_fragment_loader_html('Caricamento footer');
                     set_transient($footer_cache_key, $payload, 5 * MINUTE_IN_SECONDS);
+                    $payload['html'] = dci_apply_local_footer_signature($payload['html']);
                     return $payload;
                 }
             }
@@ -291,8 +387,10 @@ function dci_get_external_footer_payload() {
                             'css' => array(),
                             'js' => array(),
                         ),
+                        'loading_html' => dci_get_external_fragment_loader_html('Caricamento footer'),
                     );
                     set_transient($footer_cache_key, $result, 5 * MINUTE_IN_SECONDS);
+                    $result['html'] = dci_apply_local_footer_signature($result['html']);
                     return $result;
                 }
             }
@@ -339,6 +437,37 @@ function dci_get_rendered_footer() {
                 get_template_directory_uri() . '/assets/js/comuni.js',
             ),
         ),
+        'loading_html' => dci_get_external_fragment_loader_html('Caricamento footer'),
+    );
+}
+
+/**
+ * Restituisce uno snapshot HTML dell'header del tema.
+ *
+ * @return array
+ */
+function dci_get_rendered_header() {
+    ob_start();
+    locate_template('header.php', true, false);
+    $raw = ob_get_clean();
+
+    return array(
+        'success' => true,
+        'generated_at' => current_time('c'),
+        'html' => dci_extract_header_html($raw),
+        'source' => home_url('/'),
+        'assets' => array(
+            'css' => array(
+                get_template_directory_uri() . '/assets/css/bootstrap-italia-comuni.min.css',
+                get_template_directory_uri() . '/assets/css/comuni.css',
+                get_stylesheet_uri(),
+            ),
+            'js' => array(
+                get_template_directory_uri() . '/assets/js/bootstrap-italia.bundle.min.js',
+                get_template_directory_uri() . '/assets/js/comuni.js',
+            ),
+        ),
+        'loading_html' => dci_get_external_fragment_loader_html('Caricamento header'),
     );
 }
 
@@ -386,15 +515,45 @@ function dci_absolutize_external_html_urls($html, $external_home) {
     }
 
     $base_url = untrailingslashit($external_home);
-
-    return preg_replace_callback('/\b(href|src|action)=(\"|\')([^\"\']+)\2/i', function ($matches) use ($base_url) {
-        $url = trim($matches[3]);
+    $make_absolute = static function ($url) use ($base_url) {
+        $url = trim((string) $url);
 
         if ($url === '' || strpos($url, '/') !== 0 || strpos($url, '//') === 0) {
+            return $url;
+        }
+
+        return esc_url($base_url . $url);
+    };
+
+    $html = preg_replace_callback('/\b(href|src|action|data-href|data-url)=("|\')([^"\']+)\2/i', function ($matches) use ($make_absolute) {
+        $absolute_url = $make_absolute($matches[3]);
+
+        if ($absolute_url === trim((string) $matches[3])) {
             return $matches[0];
         }
 
-        return $matches[1] . '=' . $matches[2] . esc_url($base_url . $url) . $matches[2];
+        return $matches[1] . '=' . $matches[2] . $absolute_url . $matches[2];
+    }, $html);
+
+    $html = preg_replace_callback('/\b((?:window\.|document\.)?location(?:\.href)?)\s*=\s*("|\')([^"\']+)\2/i', function ($matches) use ($make_absolute) {
+        $absolute_url = $make_absolute($matches[3]);
+
+        if ($absolute_url === trim((string) $matches[3])) {
+            return $matches[0];
+        }
+
+        return $matches[1] . '=' . $matches[2] . $absolute_url . $matches[2];
+    }, $html);
+
+    return preg_replace_callback('/url\(("|\')?([^\)"\']+)\1\)/i', function ($matches) use ($make_absolute) {
+        $absolute_url = $make_absolute($matches[2]);
+
+        if ($absolute_url === trim((string) $matches[2])) {
+            return $matches[0];
+        }
+
+        $quote = isset($matches[1]) ? $matches[1] : '';
+        return 'url(' . $quote . $absolute_url . $quote . ')';
     }, $html);
 }
 
@@ -597,6 +756,20 @@ function dci_get_external_header_html() {
         'user-agent' => 'PSR-Theme-Header-Fetch/1.0 (+'. home_url('/') .')',
         'sslverify' => false,
     );
+
+    foreach ($candidate_homes as $candidate_home) {
+        $external_api = trailingslashit($candidate_home) . 'wp-json/wp/v2/header/rendered/';
+        $api_response = wp_remote_get($external_api, $request_args);
+
+        if (!is_wp_error($api_response) && wp_remote_retrieve_response_code($api_response) === 200) {
+            $payload = json_decode(wp_remote_retrieve_body($api_response), true);
+            if (is_array($payload) && !empty($payload['html'])) {
+                $header_html = dci_absolutize_external_html_urls($payload['html'], $external_home);
+                set_transient($header_cache_key, $header_html, 5 * MINUTE_IN_SECONDS);
+                return $header_html;
+            }
+        }
+    }
 
     foreach ($candidate_homes as $candidate_home) {
         $response = wp_remote_get($candidate_home, $request_args);

--- a/single-documento_pubblico.php
+++ b/single-documento_pubblico.php
@@ -252,9 +252,26 @@ get_header();
                                 // Cicla gli allegati (multipli o singolo convertito)
                                 if (!empty($file_documento)) {
                                     foreach ($file_documento as $file_url) {
-                                        $documento_id = attachment_url_to_postid($file_url);
-                                        $documento = get_post($documento_id);
-                                        $titolo = $documento ? $documento->post_title : basename($file_url);
+                                        if (is_array($file_url)) {
+                                            continue;
+                                        }
+
+                                        $file_url = trim((string) $file_url);
+                                        $documento_id = is_numeric($file_url) ? absint($file_url) : attachment_url_to_postid($file_url);
+
+                                        if ($documento_id && is_numeric($file_url)) {
+                                            $attachment_url = wp_get_attachment_url($documento_id);
+                                            if ($attachment_url) {
+                                                $file_url = $attachment_url;
+                                            }
+                                        }
+
+                                        if ($file_url === '') {
+                                            continue;
+                                        }
+
+                                        $documento = $documento_id ? get_post($documento_id) : null;
+                                        $titolo = $documento ? $documento->post_title : basename((string) wp_parse_url($file_url, PHP_URL_PATH));
                                         ?>
                                         <div class="card card-teaser shadow-sm p-4 mt-3 rounded border border-light flex-nowrap">
                                             <svg class="icon" aria-hidden="true">
@@ -266,7 +283,7 @@ get_header();
                                                         aria-label="Scarica il documento <?php echo esc_attr($titolo); ?>"
                                                         title="Scarica il documento <?php echo esc_attr($titolo); ?>">
                                                         <?php echo esc_html($titolo); ?>
-                                                        (<?php echo getFileSizeAndFormat($file_url); ?>)
+                                                        (<?php echo esc_html(getFileSizeAndFormat($file_url)); ?>)
                                                     </a>
                                                 </h5>
                                             </div>

--- a/style.css
+++ b/style.css
@@ -936,6 +936,32 @@ svg.leaflet-image-layer.leaflet-interactive path {
   fill: #333 !important;
 }
 
+
+/* Back to top: override Bootstrap Italia default green button. */
+.back-to-top,
+.back-to-top.back-to-top-small,
+.back-to-top.back-to-top-show,
+.back-to-top:hover,
+.back-to-top:focus {
+  background: #ffffff !important;
+  background-color: #ffffff !important;
+}
+
+#backToTop .icon,
+#backToTop .icon use,
+.back-to-top .icon,
+.back-to-top .icon use {
+  color: #000000 !important;
+  fill: #000000 !important;
+  stroke: none !important;
+}
+
+#backToTop .icon *,
+.back-to-top .icon * {
+  color: #000000 !important;
+  fill: #000000 !important;
+}
+
 /* Sticky main navigation: keeps only the header menu visible while scrolling. */
 :root {
   --dci-sticky-header-nav-height: 0px;
@@ -1028,6 +1054,25 @@ body.dci-sticky-header-nav-active .dci-sticky-nav-search .search-link {
   body.dci-sticky-header-nav-active .dci-sticky-nav-search {
     display: none;
   }
+}
+
+
+/* Loader for header/footer fragments consumed through the REST API. */
+.dci-api-fragment-loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 64px;
+  padding: 16px;
+}
+
+.dci-api-fragment-loader__spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid rgba(0, 102, 204, 0.2);
+  border-top-color: #06c;
+  border-radius: 50%;
+  animation: dci-async-loader-spin 0.8s linear infinite;
 }
 
 /* Loader sezioni caricate in parallelo */

--- a/template-parts/documento/file.php
+++ b/template-parts/documento/file.php
@@ -2,45 +2,36 @@
 global $nomefile, $idfile;
 
 $icon = "svg-documents";
-if(substr($nomefile, -3) == "pdf")
-	$icon = "it-pdf-document";
-if(substr($nomefile, -3) == "doc")
-	$icon = "svg-doc-document";
-if(substr($nomefile, -4) == "docx")
-	$icon = "svg-doc-document";
-if(substr($nomefile, -3) == "xml")
-	$icon = "svg-xml-document";
-
-$ext = substr($nomefile, -4);
+if (substr((string) $nomefile, -3) == "pdf") {
+    $icon = "it-pdf-document";
+}
+if (substr((string) $nomefile, -3) == "doc") {
+    $icon = "svg-doc-document";
+}
+if (substr((string) $nomefile, -4) == "docx") {
+    $icon = "svg-doc-document";
+}
+if (substr((string) $nomefile, -3) == "xml") {
+    $icon = "svg-xml-document";
+}
 
 $attach = get_post($idfile);
 $filetocheck = get_attached_file($idfile);
-
-$filesize = filesize($filetocheck);
-$fulltype = mime_content_type($filetocheck);
-$arrtype = explode("/", $fulltype);
-$arrtype_more = explode(".", $arrtype[count($arrtype)-1]);
-if(is_array($arrtype_more)) {
-    $arrtype = $arrtype_more;
-}
-$type = "file";
-if(is_array($arrtype))
-    $type = $arrtype[count($arrtype)-1];
-
-$ptitle = $attach->post_title;
-if(trim($ptitle) == ""){
-    $ptitle = str_replace("-", " ", basename($filetocheck, $ext));
-    $ptitle = str_replace("_", " ", $ptitle);
+$file_url = wp_get_attachment_url($idfile);
+$file_info = $file_url ? getFileSizeAndFormat($file_url) : 'FILE';
+$ptitle = $attach ? $attach->post_title : '';
+if (trim($ptitle) == "") {
+    $filename = $filetocheck ? basename($filetocheck) : (string) $nomefile;
+    $ptitle = str_replace(array("-", "_"), " ", pathinfo($filename, PATHINFO_FILENAME));
 }
 ?>
-	<div class="card card-bg card-icon rounded">
-		<div class="card-body">
-			<svg class="icon <?php echo $icon; ?>"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#<?php echo $icon; ?>"></use></svg>
-			<div class="card-icon-content">
-				<p><strong><a target="_blank" href="<?php echo $attach->guid; ?>"><?php echo $ptitle; ?></a></strong></p>
-				<small><?php echo $type; ?> - <?php echo intval($filesize/1024); ?> kb</small>
-			</div><!-- /card-icon-content -->
-		</div><!-- /card-body -->
-	</div><!-- /card card-bg card-icon rounded -->
+    <div class="card card-bg card-icon rounded">
+        <div class="card-body">
+            <svg class="icon <?php echo esc_attr($icon); ?>"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#<?php echo esc_attr($icon); ?>"></use></svg>
+            <div class="card-icon-content">
+                <p><strong><a target="_blank" href="<?php echo esc_url($file_url); ?>"><?php echo esc_html($ptitle); ?></a></strong></p>
+                <small><?php echo esc_html($file_info); ?></small>
+            </div><!-- /card-icon-content -->
+        </div><!-- /card-body -->
+    </div><!-- /card card-bg card-icon rounded -->
 <?php
-

--- a/template-parts/prenotazione/content.php
+++ b/template-parts/prenotazione/content.php
@@ -1,7 +1,14 @@
 <?php
     $uffici = get_posts(array(
         'posts_per_page' => -1,
+        'fields' => 'ids',
+        'post_status' => 'publish',
         'post_type' => 'unita_organizzativa',
+        'orderby' => 'post_title',
+        'order' => 'ASC',
+        'no_found_rows' => true,
+        'ignore_sticky_posts' => true,
+        'update_post_term_cache' => false,
         'meta_query' => array(
             'relation' => 'AND',
             array(

--- a/template-parts/segnalazione/content.php
+++ b/template-parts/segnalazione/content.php
@@ -5,11 +5,6 @@
     $privacy_url = dci_get_template_page_url('page-templates/privacy.php') ?: home_url('/page-templates/privacy');
     $area_riservata_url = dci_get_option('area_riservata') ?: wp_login_url();
 
-    $uffici = get_posts(array(
-        'posts_per_page' => -1,
-        'post_type' => 'unita_organizzativa'
-    ));
-
     $luoghi = get_posts(array(
         'posts_per_page' => 300,
         'fields' => 'ids',

--- a/template-parts/servizio/categorie.php
+++ b/template-parts/servizio/categorie.php
@@ -23,18 +23,6 @@ if($mostra_categiorie_servizi=="true"){
         <h2 class="title-xxlarge mb-4">Esplora per categoria</h2>
         <div class="row g-4">
             <?php foreach ($categorie_servizio_names as $categoria_servizio_name) {
-                $args = array(
-                    'post_type' => 'servizio',
-                    'posts_per_page' => -1,
-                    'tax_query' => array(
-                        array(
-                            'taxonomy' => 'categorie_servizio',
-                            'field' => 'name',
-                            'terms' => $categoria_servizio_name,
-                        ),
-                    ),
-                );
-                $servizi = get_posts($args);
                 $categoria = get_term_by('name', $categoria_servizio_name, 'categorie_servizio');
                 $url = get_term_link($categoria->term_id, 'categorie_servizio');
             ?>

--- a/template-parts/single/attachment.php
+++ b/template-parts/single/attachment.php
@@ -1,48 +1,17 @@
 <?php
 global $file_url;
 
-function formatSizeUnits($bytes)
-{
-    if ($bytes >= 1073741824)
-    {
-        $bytes = number_format($bytes / 1073741824, 2) . ' GB';
-    }
-    elseif ($bytes >= 1048576)
-    {
-        $bytes = number_format($bytes / 1048576, 2) . ' MB';
-    }
-    elseif ($bytes >= 1024)
-    {
-        $bytes = number_format($bytes / 1024, 2) . ' kB';
-    }
-    elseif ($bytes > 1)
-    {
-        $bytes = $bytes . ' bytes';
-    }
-    elseif ($bytes == 1)
-    {
-        $bytes = $bytes . ' byte';
-    }
-    else
-    {
-        $bytes = '0 bytes';
-    }
-
-    return $bytes;
-}
-
-$attachment_id = attachment_url_to_postid($file_url) ;
-$size = formatSizeUnits( filesize( get_attached_file( $attachment_id ) ) );
-$extension = strtoupper( wp_check_filetype($file_url)['ext'] );
+$file_url = trim((string) $file_url);
+$file_info = getFileSizeAndFormat($file_url);
 ?>
 
 <div class="cmp-icon-link">
-    <a class="list-item icon-left d-inline-block" href="<?php echo $file_url; ?>" aria-label="Scarica Termini e condizioni di servizio (<?php echo $extension.' '.$size; ?>)" data-element="service-file">
+    <a class="list-item icon-left d-inline-block" href="<?php echo esc_url($file_url); ?>" aria-label="Scarica Termini e condizioni di servizio (<?php echo esc_attr($file_info); ?>)" data-element="service-file">
     <span class="list-item-title-icon-wrapper">
         <svg class="icon icon-primary icon-sm me-1" aria-hidden="true">
         <use href="#it-clip"></use>
         </svg>
-        <span class="list-item t-primary">Termini e condizioni di servizio (<?php echo $extension.' '.$size; ?>)</span>
+        <span class="list-item t-primary">Termini e condizioni di servizio (<?php echo esc_html($file_info); ?>)</span>
     </span>
     </a>
 </div>


### PR DESCRIPTION
### Motivation

- Make async template-part loading more robust by adding retry cycles and an inline retry UI instead of forcing a full-page fallback.
- Expose header markup via REST and harmonize external footer fetching so local branding (signature) can be applied to fetched fragments.
- Improve file/attachment handling to reliably show file format and a readable size for local attachments and various template usages.
- Tweak back-to-top styling and add loader visuals for API-provided fragments for better accessibility and UX.

### Description

- Rewrote `assets/js/async-template-parts.js` to add `getLoaderMarkup`, schedule retry logic with `data-retry-count`, `maxRetries` and `timeoutMs` support, and to show an inline retry button instead of redirecting to a sync URL.
- Added REST route registration for `wp/v2/header/rendered/`, implemented `dci_get_rendered_header()`, `dci_get_external_fragment_loader_html()` and improved external footer fetching in `inc/funzionalita_trasversali.php`, including `dci_apply_local_footer_signature()` to append the local signature when appropriate.
- Reworked cache bumping hooks in `functions.php` to only bump on a curated set of options via `dci_maybe_bump_async_template_parts_cache_version_on_option`, added `dci_format_file_size()` and revamped `getFileSizeAndFormat()` to handle numeric attachment IDs, local files (returning human-readable sizes), and safer URL parsing.
- Updated templates to use the new file helpers and sanitization: `single-documento_pubblico.php`, `template-parts/documento/file.php`, and `template-parts/single/attachment.php` now trim and validate URLs/IDs and display formatted file info; other templates were optimized (e.g. queries limited with `fields => 'ids'` and ordering).
- Added CSS rules in `style.css` for API fragment loader, async template loaders, and to override the default back-to-top button color/icon to black, and improved footer markup: `footer.php` now uses `dci_get_footer_signature_html()` for footer signature rendering and improves back-to-top accessibility attributes.
- Miscellaneous cleanups and defensive changes across templates to improve escaping and type casting where appropriate.

### Testing

- Ran PHP syntax checks (`php -l`) on the modified PHP files and they passed.
- No automated unit or integration tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd038ec848332a536b35d07917d72)