### PR TITLE
Improve async template loading reliability, caching and AJAX sanitization

### DIFF
--- a/assets/js/async-template-parts.js
+++ b/assets/js/async-template-parts.js
@@ -7,44 +7,42 @@
     return '<div class="container py-5"><div class="dci-async-loader" aria-hidden="true"><span class="dci-async-loader__spinner"></span><span class="dci-async-loader__line dci-async-loader__line--long"></span><span class="dci-async-loader__line"></span></div><span class="visually-hidden">' + message + '</span></div>';
   }
 
-  function restartTemplateRetryCycle(placeholder) {
-    placeholder.removeAttribute('data-retry-count');
-    placeholder.classList.remove('dci-async-template--error');
-    placeholder.setAttribute('aria-busy', 'true');
-    placeholder.innerHTML = getLoaderMarkup('Nuovo tentativo di caricamento della sezione');
-    loadTemplate(placeholder);
-  }
-
-  function showTemplateRetryButton(placeholder) {
+  function showTemplateTimeout(placeholder) {
     placeholder.setAttribute('aria-busy', 'false');
     placeholder.classList.add('dci-async-template--error');
-    placeholder.innerHTML = '<div class="container py-5"><p class="mb-2">Non è stato possibile caricare questa sezione.</p><button class="btn btn-primary btn-sm" type="button">Riprova</button></div>';
-    var retry = placeholder.querySelector('button');
-    if (retry) {
-      retry.addEventListener('click', function () {
-        restartTemplateRetryCycle(placeholder);
-      });
-    }
+    placeholder.innerHTML = '<div class="container py-5"><p class="mb-0">Non è stato possibile caricare questa sezione. Ricarica la pagina più tardi.</p></div>';
   }
 
   function scheduleTemplateRetry(placeholder) {
     var retryCount = parseInt(placeholder.getAttribute('data-retry-count') || '0', 10) + 1;
-    var maxRetries = parseInt(settings.maxRetries, 10) || 4;
-    var retryDelay = Math.min(20000, 2000 * retryCount);
+    var retryTimeoutMs = parseInt(settings.retryTimeoutMs, 10) || 600000;
+    var retryStartedAt = parseInt(placeholder.getAttribute('data-retry-started-at') || '0', 10);
+    var elapsedMs;
+    var retryDelay;
 
-    if (retryCount > maxRetries) {
-      showTemplateRetryButton(placeholder);
-      return;
+    if (!retryStartedAt) {
+      retryStartedAt = Date.now();
+      placeholder.setAttribute('data-retry-started-at', retryStartedAt);
     }
+
+    elapsedMs = Date.now() - retryStartedAt;
+    if (elapsedMs >= retryTimeoutMs) {
+      showTemplateTimeout(placeholder);
+      return Promise.resolve();
+    }
+
+    retryDelay = Math.min(20000, 2000 * retryCount, retryTimeoutMs - elapsedMs);
 
     placeholder.setAttribute('data-retry-count', retryCount);
     placeholder.setAttribute('aria-busy', 'true');
     placeholder.classList.remove('dci-async-template--error');
     placeholder.innerHTML = getLoaderMarkup('Nuovo tentativo di caricamento della sezione');
 
-    window.setTimeout(function () {
-      loadTemplate(placeholder);
-    }, retryDelay);
+    return new Promise(function (resolve) {
+      window.setTimeout(function () {
+        resolve(loadTemplate(placeholder));
+      }, retryDelay);
+    });
   }
 
   function getAjaxUrl() {
@@ -113,7 +111,7 @@
 
     var body = new URLSearchParams();
     var controller = window.AbortController ? new AbortController() : null;
-    var timeoutMs = parseInt(settings.timeoutMs, 10) || 15000;
+    var timeoutMs = parseInt(settings.timeoutMs, 10) || 12000;
     var timeoutId = null;
     var fetchOptions;
 
@@ -160,6 +158,7 @@
         }
 
         placeholder.removeAttribute('data-retry-count');
+        placeholder.removeAttribute('data-retry-started-at');
         var wrapper = document.createElement('div');
         wrapper.innerHTML = payload.data.html;
         wrapper.className = 'dci-async-template__content';
@@ -172,13 +171,13 @@
           window.clearTimeout(timeoutId);
         }
 
-        scheduleTemplateRetry(placeholder);
+        return scheduleTemplateRetry(placeholder);
       });
   }
 
   function boot() {
     var placeholders = Array.prototype.slice.call(document.querySelectorAll('.dci-async-template[data-template-key]'));
-    var maxConcurrent = parseInt(settings.maxConcurrent, 10) || 3;
+    var maxConcurrent = parseInt(settings.maxConcurrent, 10) || 2;
     var active = 0;
     var index = 0;
 

--- a/functions.php
+++ b/functions.php
@@ -162,6 +162,46 @@ function dci_async_template_parts_cache_ttl() {
     return 60;
 }
 
+/**
+ * Usa la cache persistente solo quando WordPress dispone di un object cache esterno.
+ *
+ * I transient salvati nel database generano letture/scritture continue su wp_options
+ * per ogni frammento AJAX e possono diventare un collo di bottiglia sui portali
+ * Aruba senza Redis/Memcached.
+ *
+ * @return bool
+ */
+function dci_async_template_parts_use_persistent_cache() {
+    return (bool) apply_filters('dci_async_template_parts_use_persistent_cache', wp_using_ext_object_cache());
+}
+
+function dci_async_template_parts_cache_group() {
+    return 'dci_async_template_parts';
+}
+
+
+/**
+ * Impostazioni conservative per i caricamenti asincroni.
+ *
+ * Sono filtrabili per poter intervenire rapidamente in produzione senza cambiare
+ * template o JavaScript se un hosting condiviso richiede valori ancora più bassi.
+ *
+ * @return array
+ */
+function dci_async_template_parts_frontend_settings() {
+    $settings = apply_filters('dci_async_template_parts_frontend_settings', array(
+        'maxConcurrent' => 2,
+        'timeoutMs' => 12000,
+        'retryTimeoutMs' => 10 * MINUTE_IN_SECONDS * 1000,
+    ));
+
+    return array(
+        'maxConcurrent' => max(1, min(3, absint($settings['maxConcurrent'] ?? 2))),
+        'timeoutMs' => max(5000, min(30000, absint($settings['timeoutMs'] ?? 12000))),
+        'retryTimeoutMs' => max(60000, min(30 * MINUTE_IN_SECONDS * 1000, absint($settings['retryTimeoutMs'] ?? 10 * MINUTE_IN_SECONDS * 1000))),
+    );
+}
+
 function dci_async_template_parts_cache_version() {
     $version = get_option('dci_async_template_parts_cache_version');
 
@@ -220,7 +260,7 @@ add_action('deleted_option', 'dci_maybe_bump_async_template_parts_cache_version_
 function dci_async_template_parts_cache_key($template_key, $page_id, $term_id, $taxonomy, $query_string, $current_url = '') {
     return 'dci_async_tpl_' . md5(wp_json_encode(array(
         'version' => dci_async_template_parts_cache_version(),
-        'schema' => 'pagination-path-v2',
+        'schema' => 'object-cache-v1',
         'template_key' => $template_key,
         'page_id' => (int) $page_id,
         'term_id' => (int) $term_id,
@@ -322,9 +362,11 @@ function dci_load_template_part_ajax() {
         }
     }
 
-    $cache_key = dci_async_template_parts_cache_key($template_key, $page_id, $term_id, $taxonomy, $query_string, $current_url);
-    if (!is_user_logged_in()) {
-        $cached_html = get_transient($cache_key);
+    $use_persistent_cache = !is_user_logged_in() && dci_async_template_parts_use_persistent_cache();
+    $cache_key = '';
+    if ($use_persistent_cache) {
+        $cache_key = dci_async_template_parts_cache_key($template_key, $page_id, $term_id, $taxonomy, $query_string, $current_url);
+        $cached_html = wp_cache_get($cache_key, dci_async_template_parts_cache_group());
         if (false !== $cached_html) {
             wp_send_json_success(array('html' => $cached_html, 'cached' => true));
         }
@@ -346,8 +388,8 @@ function dci_load_template_part_ajax() {
         wp_reset_postdata();
     }
 
-    if (!is_user_logged_in()) {
-        set_transient($cache_key, $html, dci_async_template_parts_cache_ttl());
+    if ($use_persistent_cache) {
+        wp_cache_set($cache_key, $html, dci_async_template_parts_cache_group(), dci_async_template_parts_cache_ttl());
     }
 
     wp_send_json_success(array('html' => $html, 'cached' => false));
@@ -586,11 +628,12 @@ function dci_scripts() {
 	wp_enqueue_script( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/js/accessibility-toolbar.js', array(), false, true);
 	wp_script_add_data( 'dci-accessibility-toolbar', 'defer', true );
 	wp_enqueue_script( 'dci-async-template-parts', get_template_directory_uri() . '/assets/js/async-template-parts.js', array(), filemtime(get_template_directory() . '/assets/js/async-template-parts.js'), true );
+	$async_template_parts_settings = dci_async_template_parts_frontend_settings();
 	wp_localize_script( 'dci-async-template-parts', 'dciAsyncTemplateParts', array(
 		'ajaxurl' => admin_url( 'admin-ajax.php', 'relative' ),
-		'maxConcurrent' => 2,
-		'maxRetries' => 4,
-		'timeoutMs' => 20000,
+		'maxConcurrent' => $async_template_parts_settings['maxConcurrent'],
+		'timeoutMs' => $async_template_parts_settings['timeoutMs'],
+		'retryTimeoutMs' => $async_template_parts_settings['retryTimeoutMs'],
 	) );
 	wp_script_add_data( 'dci-async-template-parts', 'defer', true );
 	wp_add_inline_script( 'dci-comuni', 'window.wpRestApi = "' . get_rest_url() . '"', 'before' );

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -193,6 +193,27 @@ function dci_should_fetch_external_footer() {
 }
 
 
+/**
+ * Argomenti HTTP prudenti per recuperare frammenti dal portale principale.
+ *
+ * Timeout più bassi e cache negativa evitano che un portale esterno lento blocchi
+ * troppo a lungo il render PHP del sito Trasparenza.
+ *
+ * @param string $context Contesto usato nello user-agent.
+ * @return array
+ */
+function dci_get_external_fragment_request_args($context = 'Fragment') {
+    $timeout = (int) apply_filters('dci_external_fragment_request_timeout', 2, $context);
+
+    return array(
+        'timeout' => max(1, min(4, $timeout)),
+        'redirection' => 2,
+        'user-agent' => 'PSR-Theme-' . sanitize_key($context) . '-Fetch/1.0 (+' . home_url('/') . ')',
+        'sslverify' => false,
+    );
+}
+
+
 
 /**
  * Restituisce la base pubblica da usare negli HTML header/footer esportati via API.
@@ -332,12 +353,7 @@ function dci_get_external_footer_payload() {
 
         $current_home = trailingslashit(home_url('/'));
         $external_parts = wp_parse_url($external_home);
-        $request_args = array(
-            'timeout' => 4,
-            'redirection' => 3,
-            'user-agent' => 'PSR-Theme-Footer-Fetch/1.0 (+'. home_url('/') .')',
-            'sslverify' => false,
-        );
+        $request_args = dci_get_external_fragment_request_args('Footer');
         $attempted_sources = array();
 
         $candidate_homes = array();
@@ -423,10 +439,10 @@ function dci_get_external_footer_payload() {
         }
 
         // Negative cache per evitare timeout ripetuti ad ogni request.
-        set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
+        set_transient($cache_key, array('html' => ''), 5 * MINUTE_IN_SECONDS);
     }
 
-    set_transient($footer_cache_key, array('success' => false, 'html' => ''), MINUTE_IN_SECONDS);
+    set_transient($footer_cache_key, array('success' => false, 'html' => ''), 5 * MINUTE_IN_SECONDS);
     return null;
 }
 
@@ -711,7 +727,7 @@ function dci_get_external_head_html() {
 
     $external_html = dci_get_external_home_snapshot($external_home, $candidate_homes);
     if ($external_html === '') {
-        set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
+        set_transient($cache_key, array('html' => ''), 5 * MINUTE_IN_SECONDS);
         return '';
     }
 
@@ -722,7 +738,7 @@ function dci_get_external_head_html() {
         return $head_html;
     }
 
-    set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
+    set_transient($cache_key, array('html' => ''), 5 * MINUTE_IN_SECONDS);
     return '';
 }
 
@@ -744,12 +760,7 @@ function dci_get_external_home_snapshot($external_home, $candidate_homes = array
         $candidate_homes = array(trailingslashit($external_home));
     }
 
-    $request_args = array(
-        'timeout' => 4,
-        'redirection' => 3,
-        'user-agent' => 'PSR-Theme-Head-Fetch/1.0 (+'. home_url('/') .')',
-        'sslverify' => false,
-    );
+    $request_args = dci_get_external_fragment_request_args('Head');
 
     foreach ($candidate_homes as $candidate_home) {
         $response = wp_remote_get($candidate_home, $request_args);
@@ -762,7 +773,7 @@ function dci_get_external_home_snapshot($external_home, $candidate_homes = array
         }
     }
 
-    set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
+    set_transient($cache_key, array('html' => ''), 5 * MINUTE_IN_SECONDS);
     return '';
 }
 
@@ -803,12 +814,7 @@ function dci_get_external_header_html() {
     $candidate_homes[] = $external_parts['scheme'] . '://' . $external_parts['host'] . '/';
     $candidate_homes = array_values(array_unique(array_filter($candidate_homes)));
 
-    $request_args = array(
-        'timeout' => 4,
-        'redirection' => 3,
-        'user-agent' => 'PSR-Theme-Header-Fetch/1.0 (+'. home_url('/') .')',
-        'sslverify' => false,
-    );
+    $request_args = dci_get_external_fragment_request_args('Header');
 
     foreach ($candidate_homes as $candidate_home) {
         $external_api = trailingslashit($candidate_home) . 'wp-json/wp/v2/header/rendered/';
@@ -836,7 +842,7 @@ function dci_get_external_header_html() {
         }
     }
 
-    set_transient($header_cache_key, '__empty__', MINUTE_IN_SECONDS);
+    set_transient($header_cache_key, '__empty__', 5 * MINUTE_IN_SECONDS);
     return '';
 }
 

--- a/inc/load_more.php
+++ b/inc/load_more.php
@@ -27,20 +27,36 @@ function load_template_part($template_name, $part_name=null) {
 add_action("wp_ajax_load_more" , "load_more");
 add_action("wp_ajax_nopriv_load_more" , "load_more");
 function load_more(){
-	global $wp_query, $servizio, $i, $hide_categories;
+	global $servizio, $i, $hide_categories;
 	
     // prepare our arguments for the query
-	$load_card_type = $_POST['load_card_type'];
-	$post_types = json_decode( stripslashes( $_POST['post_types'] ), true );
-	$url_query_params =  json_decode( stripslashes( $_POST['query_params'] ), true );
-	$additional_filter =  json_decode( stripslashes( $_POST['additional_filter'] ), true );
+	$load_card_type = isset($_POST['load_card_type']) ? sanitize_key(wp_unslash($_POST['load_card_type'])) : '';
+	$post_types = isset($_POST['post_types']) ? json_decode(stripslashes((string) $_POST['post_types']), true) : array();
+	$url_query_params = isset($_POST['query_params']) ? json_decode(stripslashes((string) $_POST['query_params']), true) : array();
+	$additional_filter = isset($_POST['additional_filter']) ? json_decode(stripslashes((string) $_POST['additional_filter']), true) : array();
+	$tax_query = isset($_POST['tax_query']) ? json_decode(stripslashes((string) $_POST['tax_query']), true) : array();
+	$filter_ids = isset($_POST['filter_ids']) ? json_decode(stripslashes((string) $_POST['filter_ids']), true) : array();
 	$post_count = isset($_POST['post_count']) ? absint($_POST['post_count']) : 0;
 	$load_posts = dci_sanitize_posts_per_page(isset($_POST['load_posts']) ? $_POST['load_posts'] : 6, 6, 24);
+	$search = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
+
+	if (!is_array($url_query_params)) {
+		$url_query_params = array();
+	}
+	if (!is_array($additional_filter)) {
+		$additional_filter = array();
+	}
+	if (!is_array($tax_query)) {
+		$tax_query = array();
+	}
+	if (!is_array($filter_ids)) {
+		$filter_ids = array();
+	}
 
 	switch ($post_types){
 			case "notizia":
 				$args = array(
-					's' => $_POST['search'],
+					's' => $search,
 					'posts_per_page' => $load_posts,
 					'post_type'      => $post_types,
 					'offset'         => $post_count,
@@ -57,7 +73,7 @@ function load_more(){
 				break;
 			case "servizio":
 				$args = array(
-					's' => $_POST['search'],
+					's' => $search,
 					'posts_per_page' => $load_posts,
 					'post_type'      => $post_types,
 					'post_status'    => 'publish',
@@ -67,7 +83,7 @@ function load_more(){
 				break;
 			case "luogo":
 				$args = array(
-				's' => $_POST['search'],
+				's' => $search,
 				'posts_per_page' => $load_posts,
 				'post_type'      => $post_types,
 				'post_status'    => 'publish',
@@ -77,7 +93,7 @@ function load_more(){
 			break;
 			default:
 				$args = array(
-					's' => $_POST['search'],
+					's' => $search,
 					'posts_per_page' => $load_posts,
 					'post_type'      => $post_types,
 					'post_status'    => 'publish',
@@ -101,19 +117,22 @@ function load_more(){
 	}
 	if ( isset($url_query_params["post_types"]) ) $args['post_type'] = $url_query_params["post_types"];
 	if ( isset($url_query_params["s"]) ) $args['s'] = $url_query_params["s"];
-	if ( isset($additional_filter) ) $args = $args + $additional_filter;
+	if (!empty($tax_query)) $args['tax_query'] = $tax_query;
+	if (!empty($filter_ids)) $args['post__in'] = array_values(array_filter(array_map('absint', $filter_ids)));
+	if (!empty($additional_filter)) $args = array_merge($args, $additional_filter);
+	$args['posts_per_page'] = $load_posts;
+	$args['post_status'] = 'publish';
 	$args['offset'] = $post_count;
 	$args['ignore_sticky_posts'] = true;
  
-	// it is always better to use WP_Query but not here
-	$new_query = query_posts( $args );
+	$new_query = new WP_Query( $args );
 
 	$out = '';
-    if( have_posts() ) :
+    if( $new_query->have_posts() ) :
 		
 		$i = 0;
 		// run the loop
-		while( have_posts() ): the_post();
+		while( $new_query->have_posts() ): $new_query->the_post();
 		$post = get_post();
 		++$i;
 
@@ -156,12 +175,11 @@ function load_more(){
 
 	$res = array();
 	$res['response'] = $out;
-	$loaded_count = count($new_query);
+	$loaded_count = (int) $new_query->post_count;
 	$res['post_count'] = $post_count + $loaded_count;
-	if (($post_count + $loaded_count) >= (int) $wp_query->found_posts) {
+	if (($post_count + $loaded_count) >= (int) $new_query->found_posts) {
 		$res['all_results'] = true;
 	}
-	$res = json_encode($res);
     wp_reset_postdata();
-    die($res);
+	wp_send_json($res);
 }

--- a/taxonomy-tipi_documento.php
+++ b/taxonomy-tipi_documento.php
@@ -8,18 +8,23 @@
 global $the_query, $load_posts, $load_card_type, $documento, $tax_query, $title, $description, $data_element, $hide_categories;
 
 $obj = get_queried_object();
-$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 6, 6, 50);
-$load_posts = 3;
+$per_page = dci_sanitize_posts_per_page(apply_filters('dci_document_taxonomy_posts_per_page', 9), 9, 24);
+$load_posts = $per_page;
 $query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
+$paged_from_query = get_query_var('paged');
+$paged_from_get = isset($_GET['paged']) ? absint($_GET['paged']) : 0;
+$paged = max(1, (int) ($paged_from_query ? $paged_from_query : $paged_from_get));
 
 // Aggiungi un filtro tax_query per limitare i risultati ai documenti della tassonomia selezionata
 $args = array(
     's' => $query,
-    'posts_per_page' => $max_posts,
+    'posts_per_page' => $per_page,
     'post_status'    => 'publish',
     'post_type'      => 'documento_pubblico',
     'orderby'        => 'text_date_timestamp',    
     'order'          => 'DESC',
+    'ignore_sticky_posts' => true,
+    'paged'          => $paged,
     'tax_query'      => array(
         array(
             'taxonomy' => 'tipi_documento', // La tassonomia personalizzata
@@ -30,7 +35,6 @@ $args = array(
 );
 
 $the_query = new WP_Query($args);
-$documenti = $the_query->posts;
 
 get_header();
 ?>
@@ -58,7 +62,7 @@ get_header();
                     placeholder="Cerca una parola chiave"
                     id="autocomplete-two"
                     name="search"
-                    value="<?php echo $query; ?>"
+                    value="<?php echo esc_attr($query); ?>"
                     data-bs-autocomplete="[]">
                   <div class="input-group-append">
                       <button class="btn btn-primary" type="submit" id="button-3">
@@ -73,14 +77,28 @@ get_header();
                   <p id="autocomplete-label" class="mb-4"><strong><?php echo $the_query->found_posts; ?> </strong>documenti trovati in ordine alfabetico</p>
                 </div>
                 <div class="row g-4" id="load-more">
-                    <?php foreach ($documenti as $post) { 
-                        $load_card_type = "documento";
-                        $hide_categories = true;
-                        $full_width = true;
-                        get_template_part("template-parts/documento/cards-list");    
-                    } ?>
+                    <?php
+                    $load_card_type = "documento";
+                    $hide_categories = true;
+                    $full_width = true;
+
+                    if ($the_query->have_posts()) {
+                        while ($the_query->have_posts()) {
+                            $the_query->the_post();
+                            get_template_part("template-parts/documento/cards-list");
+                        }
+                    } else {
+                        get_template_part('template-parts/content', 'none');
+                    }
+                    ?>
                 </div>
-                <?php get_template_part("template-parts/search/more-results"); ?>
+                <?php if ($the_query->max_num_pages > 1) : ?>
+                    <div class="row my-4">
+                        <nav class="pagination-wrapper justify-content-center col-12" aria-label="Navigazione pagine documenti">
+                            <?php echo dci_bootstrap_pagination($the_query, false); ?>
+                        </nav>
+                    </div>
+                <?php endif; ?>
               </div>
             </div>
           </div>
@@ -91,5 +109,6 @@ get_header();
     <?php echo get_template_part( 'template-parts/common/assistenza-contatti'); ?>
 </main>
 <?php
+wp_reset_postdata();
 get_footer();
 ?>

--- a/template-parts/amministrazione-trasparente/articolazione-uffici/tutti-uffici.php
+++ b/template-parts/amministrazione-trasparente/articolazione-uffici/tutti-uffici.php
@@ -3,7 +3,7 @@ global $the_query, $load_posts;
 global $siti_tematici, $dci_amm_sidebar_embedded, $dci_amm_sidebar_sections;
 
 $count = 0;
-$max_posts = isset($_GET['max_posts']) ? (int) $_GET['max_posts'] : 1000000;
+$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 300, 300, 300);
 $load_posts = 6;
 $query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
 $siti_tematici = !empty(dci_get_option('siti_tematici', 'trasparenza')) ? dci_get_option('siti_tematici', 'trasparenza') : [];

--- a/template-parts/amministrazione-trasparente/atto-concessione/tutti-gli-atti.php
+++ b/template-parts/amministrazione-trasparente/atto-concessione/tutti-gli-atti.php
@@ -5,7 +5,7 @@ remove_filter('template_redirect', 'redirect_canonical');
 global $wpdb;
 
 // Lettura parametri da URL
-$max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 10;
+$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 10, 10, 50);
 $main_search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
 $paged_from_query = max(1, (int) get_query_var('paged'));
 $paged_from_page  = max(1, (int) get_query_var('page'));

--- a/template-parts/amministrazione-trasparente/incarichi-autorizzazioni/tutti-gli-incarichi.php
+++ b/template-parts/amministrazione-trasparente/incarichi-autorizzazioni/tutti-gli-incarichi.php
@@ -4,7 +4,7 @@ remove_filter('template_redirect', 'redirect_canonical');
 
 global $wpdb;
 
-$max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 5;
+$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 5, 5, 50);
 $main_search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
 $paged = max(1, (int) get_query_var('paged'));
 if ($paged < 2) {

--- a/template-parts/amministrazione-trasparente/titolare_incarico/tutti-titolari.php
+++ b/template-parts/amministrazione-trasparente/titolare_incarico/tutti-titolari.php
@@ -1,7 +1,7 @@
 <?php
 global $wpdb;
 
-$max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 10;
+$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 10, 10, 50);
 $main_search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
 $paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
 $selected_year = isset($_GET['filter_year']) ? intval($_GET['filter_year']) : 0;
@@ -37,7 +37,6 @@ if ($selected_year > 0) {
     ];
 }
 
-$the_query = new WP_Query($args);
 $prefix = "_dci_titolare_incarico_";
 
 // Query personalizzata

--- a/template-parts/amministrazione-trasparente/titolari-incarichi-poilitici/tutti-titolari.php
+++ b/template-parts/amministrazione-trasparente/titolari-incarichi-poilitici/tutti-titolari.php
@@ -19,7 +19,9 @@ if($portale_esterno === 'false'){
 
     $args = array(
         'post_type' => 'unita_organizzativa',
-        'posts_per_page' => -1,
+        'posts_per_page' => 100,
+        'no_found_rows' => true,
+        'update_post_meta_cache' => false,
         'tax_query' => array(
             array(
                 'taxonomy' => 'tipi_unita_organizzativa',

--- a/template-parts/politici/tutti-politici.php
+++ b/template-parts/politici/tutti-politici.php
@@ -22,14 +22,18 @@ $tax_query = array(
 $args_incarichi = array(
     'post_type' => 'incarico',
     'tax_query' => $tax_query,
-    'posts_per_page' => -1
+    'posts_per_page' => -1,
+    'fields' => 'ids',
+    'no_found_rows' => true,
+    'update_post_meta_cache' => false,
+    'update_post_term_cache' => false,
 );
 
 $incarichi_posts = get_posts($args_incarichi);
 $persone_ids = array();
 
-foreach($incarichi_posts as $incarico) {
-    $persone = get_post_meta($incarico->ID, '_dci_incarico_persona');
+foreach($incarichi_posts as $incarico_id) {
+    $persone = get_post_meta($incarico_id, '_dci_incarico_persona');
     foreach($persone as $persona) {
         $persone_ids[] = $persona;
     }
@@ -47,6 +51,7 @@ $args = array(
     'orderby' => 'post_title',
     'order' => 'ASC',
     'post__in' => empty($persone_ids) ? [0] : $filter_ids,
+    'no_found_rows' => true,
 );
 
 $the_query = new WP_Query($args);


### PR DESCRIPTION
### Motivation
- Make async template part loading more robust under slow hosts by reducing timeouts, limiting concurrency and introducing a total retry timeout window. 
- Reduce pressure on the options table by using external object cache when available and increase negative cache windows for external fragment fetches. 
- Harden AJAX endpoints and template queries by sanitizing inputs, replacing `query_posts` with `WP_Query`, and adding performance flags for heavy queries.

### Description
- Refactor `assets/js/async-template-parts.js` to remove the manual retry button, add a total `retryTimeoutMs` window tracked via `data-retry-started-at`, return Promises from retry scheduling, lower default `timeoutMs` to 12000ms and reduce default `maxConcurrent` to 2, and update loader/error messages. 
- Add PHP helpers: `dci_async_template_parts_use_persistent_cache()`, `dci_async_template_parts_cache_group()` and `dci_async_template_parts_frontend_settings()` and use them to localize `maxConcurrent`, `timeoutMs` and `retryTimeoutMs` to the frontend; change cache key schema to `object-cache-v1` and use `wp_cache_get`/`wp_cache_set` when persistent object cache is available. 
- Introduce `dci_get_external_fragment_request_args()` and apply it to header/head/footer/home fetches, increase several negative cache TTLs from 2 to 5 minutes and standardize conservative HTTP request args. 
- Harden and modernize AJAX and template code: sanitize inputs in `inc/load_more.php`, replace `query_posts` with `WP_Query`, use `wp_send_json()` and `wp_reset_postdata()`, and compute post counts correctly; sanitize and escape template values and add proper pagination in `taxonomy-tipi_documento.php`. 
- Apply `dci_sanitize_posts_per_page()` and query performance flags (`no_found_rows`, `fields => 'ids'`, `update_post_meta_cache => false`, etc.) across multiple template parts to limit memory/DB usage and improve performance.

### Testing
- Ran PHP syntax checks (`php -l`) on the modified PHP files and they passed. 
- No automated unit tests were added to this change. 
- Basic smoke validation of AJAX responses and template rendering was performed in a development environment (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a211fa3aeec8332be2b1c61a085b306)