### PR TITLE
Accessibility toolbar: dynamic accent + async templates: safer timeouts, caching and load_more hardening

### DIFF
--- a/assets/css/accessibility-toolbar.css
+++ b/assets/css/accessibility-toolbar.css
@@ -1,10 +1,10 @@
-.dci-a11y{position:fixed;left:12px;bottom:12px;z-index:9998;font-family:Inter,Arial,sans-serif}
-.dci-a11y-toggle{border:0;background:linear-gradient(135deg,#0d3b79,#1f5daa);color:#fff;border-radius:999px;padding:10px 16px;font-weight:700;box-shadow:0 6px 20px rgba(13,59,121,.3);display:inline-flex;align-items:center;gap:6px}.dci-a11y-toggle-icon{line-height:1}.dci-a11y-toggle-label{line-height:1.2}
+.dci-a11y{position:fixed;left:12px;bottom:12px;z-index:9998;font-family:Inter,Arial,sans-serif;--dci-a11y-accent:#0d3b79;--dci-a11y-accent-strong:#1f5daa;--dci-a11y-accent-shadow:rgba(13,59,121,.3)}
+.dci-a11y-toggle{border:0;background:linear-gradient(135deg,var(--dci-a11y-accent),var(--dci-a11y-accent-strong));color:#fff;border-radius:999px;padding:10px 16px;font-weight:700;box-shadow:0 6px 20px var(--dci-a11y-accent-shadow);display:inline-flex;align-items:center;gap:6px}.dci-a11y-toggle-icon{line-height:1}.dci-a11y-toggle-label{line-height:1.2}
 .dci-a11y-panel{margin-top:10px;background:#f7f9fc;border:1px solid #dbe3ef;border-radius:12px;padding:10px;display:grid;grid-template-columns:repeat(2,minmax(150px,1fr));gap:8px;max-width:390px;max-height:62vh;overflow:auto;box-shadow:0 10px 26px rgba(10,32,66,.18)}
 .dci-a11y-btn{cursor:pointer;border:1px solid #cbd6e5;background:#fff;color:#1d2c3f;padding:10px;border-radius:10px;font-weight:600;min-height:56px;display:flex;flex-wrap:wrap;align-items:center;gap:6px 8px;text-align:left;line-height:1.2}
 .dci-a11y-ico{font-size:16px;display:inline-flex;width:18px;justify-content:center}
 .dci-a11y-btn:hover{background:#eef4ff}
-.dci-a11y-btn.is-active{background:#0d3b79;color:#fff;border-color:#0d3b79}
+.dci-a11y-btn.is-active{background:var(--dci-a11y-accent);color:#fff;border-color:var(--dci-a11y-accent)}
 .dci-a11y-btn-reset{background:#fff7f7;border-color:#f1c7c7}
 body.dci-a11y-links a{text-decoration:underline!important;text-decoration-thickness:2px!important}
 body.dci-a11y-dyslexia{font-family:Verdana,Arial,sans-serif!important;letter-spacing:.02em;word-spacing:.06em;line-height:1.7}
@@ -13,9 +13,9 @@ body.dci-a11y-highlight-all p,body.dci-a11y-highlight-all li,body.dci-a11y-highl
 body.dci-a11y-highlight-titles h1,body.dci-a11y-highlight-titles h2,body.dci-a11y-highlight-titles h3,body.dci-a11y-highlight-titles h4{background:#fff4a3!important}
 body.dci-a11y-hide-images img{display:none!important}
 body.dci-a11y-stop-animations *,body.dci-a11y-stop-animations *::before,body.dci-a11y-stop-animations *::after{animation:none!important;transition:none!important}
-body.dci-a11y-keyboard *:focus{outline:3px solid #0d3b79!important;outline-offset:2px!important}
+body.dci-a11y-keyboard *:focus{outline:3px solid var(--dci-a11y-accent,#0d3b79)!important;outline-offset:2px!important}
 [data-dci-a11y-target='1']{filter:var(--dci-a11y-filter,none)}
-@media (max-width:767px){.dci-a11y{left:8px;right:auto;bottom:8px}.dci-a11y-toggle{width:42px;height:42px;padding:0;justify-content:center;font-size:1.1rem;box-shadow:0 4px 14px rgba(13,59,121,.25)}.dci-a11y-toggle-icon{color:#fff}.dci-a11y-toggle-label{display:none}.dci-a11y-toggle[aria-expanded="true"]{width:auto;padding:0 12px}.dci-a11y-toggle[aria-expanded="true"] .dci-a11y-toggle-label{display:inline}.dci-a11y-panel{width:calc(100vw - 16px);max-width:none;grid-template-columns:1fr 1fr;max-height:55vh}}
+@media (max-width:767px){.dci-a11y{left:8px;right:auto;bottom:8px}.dci-a11y-toggle{width:42px;height:42px;padding:0;justify-content:center;font-size:1.1rem;box-shadow:0 4px 14px var(--dci-a11y-accent-shadow)}.dci-a11y-toggle-icon{color:#fff}.dci-a11y-toggle-label{display:none}.dci-a11y-toggle[aria-expanded="true"]{width:auto;padding:0 12px}.dci-a11y-toggle[aria-expanded="true"] .dci-a11y-toggle-label{display:inline}.dci-a11y-panel{width:calc(100vw - 16px);max-width:none;grid-template-columns:1fr 1fr;max-height:55vh}}
 
 body.dci-a11y-cursor-1, body.dci-a11y-cursor-1 *{cursor:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M4 2l14 9l-6 1l3.5 8l-2.2 1l-3.5-8l-4.3 4.3z'/%3E%3C/svg%3E") 3 3, auto !important;}
 body.dci-a11y-cursor-2, body.dci-a11y-cursor-2 *{cursor:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='38' height='38' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M4 2l14 9l-6 1l3.5 8l-2.2 1l-3.5-8l-4.3 4.3z'/%3E%3C/svg%3E") 3 3, auto !important;}

--- a/assets/js/accessibility-toolbar.js
+++ b/assets/js/accessibility-toolbar.js
@@ -14,6 +14,63 @@
   function cycle(name){prefs[name]=(prefs[name]+1)%levels[name].length;}
   function save(){localStorage.setItem(KEY,JSON.stringify(prefs));}
 
+  function isVisibleColor(value){
+    if(!value||value==='transparent') return false;
+    var m=value.match(/rgba?\(([^)]+)\)/i);
+    if(!m) return value!=='inherit'&&value!=='initial'&&value!=='unset';
+    var parts=m[1].split(',').map(function(part){return part.trim();});
+    return parts.length<4||parseFloat(parts[3])>0;
+  }
+
+  function rgbParts(value){
+    var m=value&&value.match(/rgba?\(([^)]+)\)/i);
+    if(!m) return null;
+    var parts=m[1].split(',').map(function(part){return parseFloat(part);});
+    if(parts.length<3||parts.some(function(part,i){return i<3&&isNaN(part);})) return null;
+    return [parts[0],parts[1],parts[2]];
+  }
+
+  function shadeColor(value,amount){
+    var rgb=rgbParts(value);
+    if(!rgb) return value;
+    return 'rgb('+rgb.map(function(channel){return clamp(Math.round(channel+amount),0,255);}).join(',')+')';
+  }
+
+  function shadowColor(value){
+    var rgb=rgbParts(value);
+    if(!rgb) return 'rgba(13,59,121,.3)';
+    return 'rgba('+rgb.map(function(channel){return Math.round(channel);}).join(',')+',.3)';
+  }
+
+  function readHeaderColor(){
+    var selectors=['.it-header-center-wrapper','.it-header-navbar-wrapper','.it-header-wrapper','header'];
+    for(var i=0;i<selectors.length;i++){
+      var el=document.querySelector(selectors[i]);
+      if(!el) continue;
+      var current=el;
+      while(current&&current!==document.body&&current!==document.documentElement){
+        var color=window.getComputedStyle(current).backgroundColor;
+        if(isVisibleColor(color)) return color;
+        current=current.parentElement;
+      }
+      var children=el.querySelectorAll('.it-header-center-wrapper,.it-header-navbar-wrapper,.it-nav-wrapper,.navbar,.container,.row,[class*="bg-"]');
+      for(var c=0;c<children.length;c++){
+        var childColor=window.getComputedStyle(children[c]).backgroundColor;
+        if(isVisibleColor(childColor)) return childColor;
+      }
+    }
+    return null;
+  }
+
+  function syncHeaderColor(){
+    var color=readHeaderColor();
+    if(!color) return;
+    wrap.style.setProperty('--dci-a11y-accent',color);
+    wrap.style.setProperty('--dci-a11y-accent-strong',shadeColor(color,24));
+    wrap.style.setProperty('--dci-a11y-accent-shadow',shadowColor(color));
+    root.style.setProperty('--dci-a11y-accent',color);
+  }
+
 
   function levelInfo(action){
     if(action==='brightness') return {current:prefs.brightness,max:levels.brightness.length-1};
@@ -107,6 +164,11 @@
     e.preventDefault();
     handleAction(b.dataset.a11yAction);
   });
+
+  syncHeaderColor();
+  if(document.readyState==='complete') syncHeaderColor();
+  else window.addEventListener('load',syncHeaderColor,{once:true});
+  window.setTimeout(syncHeaderColor,500);
 
   apply();
 })();

--- a/assets/js/async-template-parts.js
+++ b/assets/js/async-template-parts.js
@@ -7,44 +7,42 @@
     return '<div class="container py-5"><div class="dci-async-loader" aria-hidden="true"><span class="dci-async-loader__spinner"></span><span class="dci-async-loader__line dci-async-loader__line--long"></span><span class="dci-async-loader__line"></span></div><span class="visually-hidden">' + message + '</span></div>';
   }
 
-  function restartTemplateRetryCycle(placeholder) {
-    placeholder.removeAttribute('data-retry-count');
-    placeholder.classList.remove('dci-async-template--error');
-    placeholder.setAttribute('aria-busy', 'true');
-    placeholder.innerHTML = getLoaderMarkup('Nuovo tentativo di caricamento della sezione');
-    loadTemplate(placeholder);
-  }
-
-  function showTemplateRetryButton(placeholder) {
+  function showTemplateTimeout(placeholder) {
     placeholder.setAttribute('aria-busy', 'false');
     placeholder.classList.add('dci-async-template--error');
-    placeholder.innerHTML = '<div class="container py-5"><p class="mb-2">Non è stato possibile caricare questa sezione.</p><button class="btn btn-primary btn-sm" type="button">Riprova</button></div>';
-    var retry = placeholder.querySelector('button');
-    if (retry) {
-      retry.addEventListener('click', function () {
-        restartTemplateRetryCycle(placeholder);
-      });
-    }
+    placeholder.innerHTML = '<div class="container py-5"><p class="mb-0">Non è stato possibile caricare questa sezione. Ricarica la pagina più tardi.</p></div>';
   }
 
   function scheduleTemplateRetry(placeholder) {
     var retryCount = parseInt(placeholder.getAttribute('data-retry-count') || '0', 10) + 1;
-    var maxRetries = parseInt(settings.maxRetries, 10) || 4;
-    var retryDelay = Math.min(20000, 2000 * retryCount);
+    var retryTimeoutMs = parseInt(settings.retryTimeoutMs, 10) || 600000;
+    var retryStartedAt = parseInt(placeholder.getAttribute('data-retry-started-at') || '0', 10);
+    var elapsedMs;
+    var retryDelay;
 
-    if (retryCount > maxRetries) {
-      showTemplateRetryButton(placeholder);
-      return;
+    if (!retryStartedAt) {
+      retryStartedAt = Date.now();
+      placeholder.setAttribute('data-retry-started-at', retryStartedAt);
     }
+
+    elapsedMs = Date.now() - retryStartedAt;
+    if (elapsedMs >= retryTimeoutMs) {
+      showTemplateTimeout(placeholder);
+      return Promise.resolve();
+    }
+
+    retryDelay = Math.min(20000, 2000 * retryCount, retryTimeoutMs - elapsedMs);
 
     placeholder.setAttribute('data-retry-count', retryCount);
     placeholder.setAttribute('aria-busy', 'true');
     placeholder.classList.remove('dci-async-template--error');
     placeholder.innerHTML = getLoaderMarkup('Nuovo tentativo di caricamento della sezione');
 
-    window.setTimeout(function () {
-      loadTemplate(placeholder);
-    }, retryDelay);
+    return new Promise(function (resolve) {
+      window.setTimeout(function () {
+        resolve(loadTemplate(placeholder));
+      }, retryDelay);
+    });
   }
 
   function getAjaxUrl() {
@@ -113,7 +111,7 @@
 
     var body = new URLSearchParams();
     var controller = window.AbortController ? new AbortController() : null;
-    var timeoutMs = parseInt(settings.timeoutMs, 10) || 15000;
+    var timeoutMs = parseInt(settings.timeoutMs, 10) || 12000;
     var timeoutId = null;
     var fetchOptions;
 
@@ -160,6 +158,7 @@
         }
 
         placeholder.removeAttribute('data-retry-count');
+        placeholder.removeAttribute('data-retry-started-at');
         var wrapper = document.createElement('div');
         wrapper.innerHTML = payload.data.html;
         wrapper.className = 'dci-async-template__content';
@@ -172,13 +171,13 @@
           window.clearTimeout(timeoutId);
         }
 
-        scheduleTemplateRetry(placeholder);
+        return scheduleTemplateRetry(placeholder);
       });
   }
 
   function boot() {
     var placeholders = Array.prototype.slice.call(document.querySelectorAll('.dci-async-template[data-template-key]'));
-    var maxConcurrent = parseInt(settings.maxConcurrent, 10) || 3;
+    var maxConcurrent = parseInt(settings.maxConcurrent, 10) || 2;
     var active = 0;
     var index = 0;
 

--- a/functions.php
+++ b/functions.php
@@ -162,6 +162,46 @@ function dci_async_template_parts_cache_ttl() {
     return 60;
 }
 
+/**
+ * Usa la cache persistente solo quando WordPress dispone di un object cache esterno.
+ *
+ * I transient salvati nel database generano letture/scritture continue su wp_options
+ * per ogni frammento AJAX e possono diventare un collo di bottiglia sui portali
+ * Aruba senza Redis/Memcached.
+ *
+ * @return bool
+ */
+function dci_async_template_parts_use_persistent_cache() {
+    return (bool) apply_filters('dci_async_template_parts_use_persistent_cache', wp_using_ext_object_cache());
+}
+
+function dci_async_template_parts_cache_group() {
+    return 'dci_async_template_parts';
+}
+
+
+/**
+ * Impostazioni conservative per i caricamenti asincroni.
+ *
+ * Sono filtrabili per poter intervenire rapidamente in produzione senza cambiare
+ * template o JavaScript se un hosting condiviso richiede valori ancora più bassi.
+ *
+ * @return array
+ */
+function dci_async_template_parts_frontend_settings() {
+    $settings = apply_filters('dci_async_template_parts_frontend_settings', array(
+        'maxConcurrent' => 2,
+        'timeoutMs' => 12000,
+        'retryTimeoutMs' => 10 * MINUTE_IN_SECONDS * 1000,
+    ));
+
+    return array(
+        'maxConcurrent' => max(1, min(3, absint($settings['maxConcurrent'] ?? 2))),
+        'timeoutMs' => max(5000, min(30000, absint($settings['timeoutMs'] ?? 12000))),
+        'retryTimeoutMs' => max(60000, min(30 * MINUTE_IN_SECONDS * 1000, absint($settings['retryTimeoutMs'] ?? 10 * MINUTE_IN_SECONDS * 1000))),
+    );
+}
+
 function dci_async_template_parts_cache_version() {
     $version = get_option('dci_async_template_parts_cache_version');
 
@@ -220,7 +260,7 @@ add_action('deleted_option', 'dci_maybe_bump_async_template_parts_cache_version_
 function dci_async_template_parts_cache_key($template_key, $page_id, $term_id, $taxonomy, $query_string, $current_url = '') {
     return 'dci_async_tpl_' . md5(wp_json_encode(array(
         'version' => dci_async_template_parts_cache_version(),
-        'schema' => 'pagination-path-v2',
+        'schema' => 'object-cache-v1',
         'template_key' => $template_key,
         'page_id' => (int) $page_id,
         'term_id' => (int) $term_id,
@@ -322,9 +362,11 @@ function dci_load_template_part_ajax() {
         }
     }
 
-    $cache_key = dci_async_template_parts_cache_key($template_key, $page_id, $term_id, $taxonomy, $query_string, $current_url);
-    if (!is_user_logged_in()) {
-        $cached_html = get_transient($cache_key);
+    $use_persistent_cache = !is_user_logged_in() && dci_async_template_parts_use_persistent_cache();
+    $cache_key = '';
+    if ($use_persistent_cache) {
+        $cache_key = dci_async_template_parts_cache_key($template_key, $page_id, $term_id, $taxonomy, $query_string, $current_url);
+        $cached_html = wp_cache_get($cache_key, dci_async_template_parts_cache_group());
         if (false !== $cached_html) {
             wp_send_json_success(array('html' => $cached_html, 'cached' => true));
         }
@@ -346,8 +388,8 @@ function dci_load_template_part_ajax() {
         wp_reset_postdata();
     }
 
-    if (!is_user_logged_in()) {
-        set_transient($cache_key, $html, dci_async_template_parts_cache_ttl());
+    if ($use_persistent_cache) {
+        wp_cache_set($cache_key, $html, dci_async_template_parts_cache_group(), dci_async_template_parts_cache_ttl());
     }
 
     wp_send_json_success(array('html' => $html, 'cached' => false));
@@ -555,7 +597,7 @@ function dci_scripts() {
 
     wp_enqueue_style( 'dci-font', get_template_directory_uri() . '/assets/css/fonts.css', array('dci-comuni'));
     wp_enqueue_style( 'dci-wp-style', get_template_directory_uri()."/style.css", array('dci-comuni'), filemtime(get_template_directory() . '/style.css'));
-    wp_enqueue_style( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/css/accessibility-toolbar.css', array('dci-wp-style'), false );
+    wp_enqueue_style( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/css/accessibility-toolbar.css', array('dci-wp-style'), filemtime(get_template_directory() . '/assets/css/accessibility-toolbar.css') );
 
 
     wp_enqueue_script( 'dci-modernizr', get_template_directory_uri() . '/assets/js/modernizr.custom.js');
@@ -583,14 +625,15 @@ function dci_scripts() {
 	wp_enqueue_script( 'dci-sticky-header-nav', get_template_directory_uri() . '/assets/js/sticky-header-nav.js', array(), false, true);
 	wp_enqueue_script( 'dci-deferred-images', get_template_directory_uri() . '/assets/js/deferred-images.js', array(), filemtime(get_template_directory() . '/assets/js/deferred-images.js'), true);
 	wp_script_add_data( 'dci-deferred-images', 'defer', true );
-	wp_enqueue_script( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/js/accessibility-toolbar.js', array(), false, true);
+	wp_enqueue_script( 'dci-accessibility-toolbar', get_template_directory_uri() . '/assets/js/accessibility-toolbar.js', array(), filemtime(get_template_directory() . '/assets/js/accessibility-toolbar.js'), true);
 	wp_script_add_data( 'dci-accessibility-toolbar', 'defer', true );
 	wp_enqueue_script( 'dci-async-template-parts', get_template_directory_uri() . '/assets/js/async-template-parts.js', array(), filemtime(get_template_directory() . '/assets/js/async-template-parts.js'), true );
+	$async_template_parts_settings = dci_async_template_parts_frontend_settings();
 	wp_localize_script( 'dci-async-template-parts', 'dciAsyncTemplateParts', array(
 		'ajaxurl' => admin_url( 'admin-ajax.php', 'relative' ),
-		'maxConcurrent' => 2,
-		'maxRetries' => 4,
-		'timeoutMs' => 20000,
+		'maxConcurrent' => $async_template_parts_settings['maxConcurrent'],
+		'timeoutMs' => $async_template_parts_settings['timeoutMs'],
+		'retryTimeoutMs' => $async_template_parts_settings['retryTimeoutMs'],
 	) );
 	wp_script_add_data( 'dci-async-template-parts', 'defer', true );
 	wp_add_inline_script( 'dci-comuni', 'window.wpRestApi = "' . get_rest_url() . '"', 'before' );

--- a/inc/funzionalita_trasversali.php
+++ b/inc/funzionalita_trasversali.php
@@ -193,6 +193,27 @@ function dci_should_fetch_external_footer() {
 }
 
 
+/**
+ * Argomenti HTTP prudenti per recuperare frammenti dal portale principale.
+ *
+ * Timeout più bassi e cache negativa evitano che un portale esterno lento blocchi
+ * troppo a lungo il render PHP del sito Trasparenza.
+ *
+ * @param string $context Contesto usato nello user-agent.
+ * @return array
+ */
+function dci_get_external_fragment_request_args($context = 'Fragment') {
+    $timeout = (int) apply_filters('dci_external_fragment_request_timeout', 2, $context);
+
+    return array(
+        'timeout' => max(1, min(4, $timeout)),
+        'redirection' => 2,
+        'user-agent' => 'PSR-Theme-' . sanitize_key($context) . '-Fetch/1.0 (+' . home_url('/') . ')',
+        'sslverify' => false,
+    );
+}
+
+
 
 /**
  * Restituisce la base pubblica da usare negli HTML header/footer esportati via API.
@@ -332,12 +353,7 @@ function dci_get_external_footer_payload() {
 
         $current_home = trailingslashit(home_url('/'));
         $external_parts = wp_parse_url($external_home);
-        $request_args = array(
-            'timeout' => 4,
-            'redirection' => 3,
-            'user-agent' => 'PSR-Theme-Footer-Fetch/1.0 (+'. home_url('/') .')',
-            'sslverify' => false,
-        );
+        $request_args = dci_get_external_fragment_request_args('Footer');
         $attempted_sources = array();
 
         $candidate_homes = array();
@@ -423,10 +439,10 @@ function dci_get_external_footer_payload() {
         }
 
         // Negative cache per evitare timeout ripetuti ad ogni request.
-        set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
+        set_transient($cache_key, array('html' => ''), 5 * MINUTE_IN_SECONDS);
     }
 
-    set_transient($footer_cache_key, array('success' => false, 'html' => ''), MINUTE_IN_SECONDS);
+    set_transient($footer_cache_key, array('success' => false, 'html' => ''), 5 * MINUTE_IN_SECONDS);
     return null;
 }
 
@@ -711,7 +727,7 @@ function dci_get_external_head_html() {
 
     $external_html = dci_get_external_home_snapshot($external_home, $candidate_homes);
     if ($external_html === '') {
-        set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
+        set_transient($cache_key, array('html' => ''), 5 * MINUTE_IN_SECONDS);
         return '';
     }
 
@@ -722,7 +738,7 @@ function dci_get_external_head_html() {
         return $head_html;
     }
 
-    set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
+    set_transient($cache_key, array('html' => ''), 5 * MINUTE_IN_SECONDS);
     return '';
 }
 
@@ -744,12 +760,7 @@ function dci_get_external_home_snapshot($external_home, $candidate_homes = array
         $candidate_homes = array(trailingslashit($external_home));
     }
 
-    $request_args = array(
-        'timeout' => 4,
-        'redirection' => 3,
-        'user-agent' => 'PSR-Theme-Head-Fetch/1.0 (+'. home_url('/') .')',
-        'sslverify' => false,
-    );
+    $request_args = dci_get_external_fragment_request_args('Head');
 
     foreach ($candidate_homes as $candidate_home) {
         $response = wp_remote_get($candidate_home, $request_args);
@@ -762,7 +773,7 @@ function dci_get_external_home_snapshot($external_home, $candidate_homes = array
         }
     }
 
-    set_transient($cache_key, array('html' => ''), 2 * MINUTE_IN_SECONDS);
+    set_transient($cache_key, array('html' => ''), 5 * MINUTE_IN_SECONDS);
     return '';
 }
 
@@ -803,12 +814,7 @@ function dci_get_external_header_html() {
     $candidate_homes[] = $external_parts['scheme'] . '://' . $external_parts['host'] . '/';
     $candidate_homes = array_values(array_unique(array_filter($candidate_homes)));
 
-    $request_args = array(
-        'timeout' => 4,
-        'redirection' => 3,
-        'user-agent' => 'PSR-Theme-Header-Fetch/1.0 (+'. home_url('/') .')',
-        'sslverify' => false,
-    );
+    $request_args = dci_get_external_fragment_request_args('Header');
 
     foreach ($candidate_homes as $candidate_home) {
         $external_api = trailingslashit($candidate_home) . 'wp-json/wp/v2/header/rendered/';
@@ -836,7 +842,7 @@ function dci_get_external_header_html() {
         }
     }
 
-    set_transient($header_cache_key, '__empty__', MINUTE_IN_SECONDS);
+    set_transient($header_cache_key, '__empty__', 5 * MINUTE_IN_SECONDS);
     return '';
 }
 

--- a/inc/load_more.php
+++ b/inc/load_more.php
@@ -27,20 +27,36 @@ function load_template_part($template_name, $part_name=null) {
 add_action("wp_ajax_load_more" , "load_more");
 add_action("wp_ajax_nopriv_load_more" , "load_more");
 function load_more(){
-	global $wp_query, $servizio, $i, $hide_categories;
+	global $servizio, $i, $hide_categories;
 	
     // prepare our arguments for the query
-	$load_card_type = $_POST['load_card_type'];
-	$post_types = json_decode( stripslashes( $_POST['post_types'] ), true );
-	$url_query_params =  json_decode( stripslashes( $_POST['query_params'] ), true );
-	$additional_filter =  json_decode( stripslashes( $_POST['additional_filter'] ), true );
+	$load_card_type = isset($_POST['load_card_type']) ? sanitize_key(wp_unslash($_POST['load_card_type'])) : '';
+	$post_types = isset($_POST['post_types']) ? json_decode(stripslashes((string) $_POST['post_types']), true) : array();
+	$url_query_params = isset($_POST['query_params']) ? json_decode(stripslashes((string) $_POST['query_params']), true) : array();
+	$additional_filter = isset($_POST['additional_filter']) ? json_decode(stripslashes((string) $_POST['additional_filter']), true) : array();
+	$tax_query = isset($_POST['tax_query']) ? json_decode(stripslashes((string) $_POST['tax_query']), true) : array();
+	$filter_ids = isset($_POST['filter_ids']) ? json_decode(stripslashes((string) $_POST['filter_ids']), true) : array();
 	$post_count = isset($_POST['post_count']) ? absint($_POST['post_count']) : 0;
 	$load_posts = dci_sanitize_posts_per_page(isset($_POST['load_posts']) ? $_POST['load_posts'] : 6, 6, 24);
+	$search = isset($_POST['search']) ? sanitize_text_field(wp_unslash($_POST['search'])) : '';
+
+	if (!is_array($url_query_params)) {
+		$url_query_params = array();
+	}
+	if (!is_array($additional_filter)) {
+		$additional_filter = array();
+	}
+	if (!is_array($tax_query)) {
+		$tax_query = array();
+	}
+	if (!is_array($filter_ids)) {
+		$filter_ids = array();
+	}
 
 	switch ($post_types){
 			case "notizia":
 				$args = array(
-					's' => $_POST['search'],
+					's' => $search,
 					'posts_per_page' => $load_posts,
 					'post_type'      => $post_types,
 					'offset'         => $post_count,
@@ -57,7 +73,7 @@ function load_more(){
 				break;
 			case "servizio":
 				$args = array(
-					's' => $_POST['search'],
+					's' => $search,
 					'posts_per_page' => $load_posts,
 					'post_type'      => $post_types,
 					'post_status'    => 'publish',
@@ -67,7 +83,7 @@ function load_more(){
 				break;
 			case "luogo":
 				$args = array(
-				's' => $_POST['search'],
+				's' => $search,
 				'posts_per_page' => $load_posts,
 				'post_type'      => $post_types,
 				'post_status'    => 'publish',
@@ -77,7 +93,7 @@ function load_more(){
 			break;
 			default:
 				$args = array(
-					's' => $_POST['search'],
+					's' => $search,
 					'posts_per_page' => $load_posts,
 					'post_type'      => $post_types,
 					'post_status'    => 'publish',
@@ -101,19 +117,22 @@ function load_more(){
 	}
 	if ( isset($url_query_params["post_types"]) ) $args['post_type'] = $url_query_params["post_types"];
 	if ( isset($url_query_params["s"]) ) $args['s'] = $url_query_params["s"];
-	if ( isset($additional_filter) ) $args = $args + $additional_filter;
+	if (!empty($tax_query)) $args['tax_query'] = $tax_query;
+	if (!empty($filter_ids)) $args['post__in'] = array_values(array_filter(array_map('absint', $filter_ids)));
+	if (!empty($additional_filter)) $args = array_merge($args, $additional_filter);
+	$args['posts_per_page'] = $load_posts;
+	$args['post_status'] = 'publish';
 	$args['offset'] = $post_count;
 	$args['ignore_sticky_posts'] = true;
  
-	// it is always better to use WP_Query but not here
-	$new_query = query_posts( $args );
+	$new_query = new WP_Query( $args );
 
 	$out = '';
-    if( have_posts() ) :
+    if( $new_query->have_posts() ) :
 		
 		$i = 0;
 		// run the loop
-		while( have_posts() ): the_post();
+		while( $new_query->have_posts() ): $new_query->the_post();
 		$post = get_post();
 		++$i;
 
@@ -156,12 +175,11 @@ function load_more(){
 
 	$res = array();
 	$res['response'] = $out;
-	$loaded_count = count($new_query);
+	$loaded_count = (int) $new_query->post_count;
 	$res['post_count'] = $post_count + $loaded_count;
-	if (($post_count + $loaded_count) >= (int) $wp_query->found_posts) {
+	if (($post_count + $loaded_count) >= (int) $new_query->found_posts) {
 		$res['all_results'] = true;
 	}
-	$res = json_encode($res);
     wp_reset_postdata();
-    die($res);
+	wp_send_json($res);
 }

--- a/taxonomy-tipi_documento.php
+++ b/taxonomy-tipi_documento.php
@@ -8,18 +8,23 @@
 global $the_query, $load_posts, $load_card_type, $documento, $tax_query, $title, $description, $data_element, $hide_categories;
 
 $obj = get_queried_object();
-$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 6, 6, 50);
-$load_posts = 3;
+$per_page = dci_sanitize_posts_per_page(apply_filters('dci_document_taxonomy_posts_per_page', 9), 9, 24);
+$load_posts = $per_page;
 $query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
+$paged_from_query = get_query_var('paged');
+$paged_from_get = isset($_GET['paged']) ? absint($_GET['paged']) : 0;
+$paged = max(1, (int) ($paged_from_query ? $paged_from_query : $paged_from_get));
 
 // Aggiungi un filtro tax_query per limitare i risultati ai documenti della tassonomia selezionata
 $args = array(
     's' => $query,
-    'posts_per_page' => $max_posts,
+    'posts_per_page' => $per_page,
     'post_status'    => 'publish',
     'post_type'      => 'documento_pubblico',
     'orderby'        => 'text_date_timestamp',    
     'order'          => 'DESC',
+    'ignore_sticky_posts' => true,
+    'paged'          => $paged,
     'tax_query'      => array(
         array(
             'taxonomy' => 'tipi_documento', // La tassonomia personalizzata
@@ -30,7 +35,6 @@ $args = array(
 );
 
 $the_query = new WP_Query($args);
-$documenti = $the_query->posts;
 
 get_header();
 ?>
@@ -58,7 +62,7 @@ get_header();
                     placeholder="Cerca una parola chiave"
                     id="autocomplete-two"
                     name="search"
-                    value="<?php echo $query; ?>"
+                    value="<?php echo esc_attr($query); ?>"
                     data-bs-autocomplete="[]">
                   <div class="input-group-append">
                       <button class="btn btn-primary" type="submit" id="button-3">
@@ -73,14 +77,28 @@ get_header();
                   <p id="autocomplete-label" class="mb-4"><strong><?php echo $the_query->found_posts; ?> </strong>documenti trovati in ordine alfabetico</p>
                 </div>
                 <div class="row g-4" id="load-more">
-                    <?php foreach ($documenti as $post) { 
-                        $load_card_type = "documento";
-                        $hide_categories = true;
-                        $full_width = true;
-                        get_template_part("template-parts/documento/cards-list");    
-                    } ?>
+                    <?php
+                    $load_card_type = "documento";
+                    $hide_categories = true;
+                    $full_width = true;
+
+                    if ($the_query->have_posts()) {
+                        while ($the_query->have_posts()) {
+                            $the_query->the_post();
+                            get_template_part("template-parts/documento/cards-list");
+                        }
+                    } else {
+                        get_template_part('template-parts/content', 'none');
+                    }
+                    ?>
                 </div>
-                <?php get_template_part("template-parts/search/more-results"); ?>
+                <?php if ($the_query->max_num_pages > 1) : ?>
+                    <div class="row my-4">
+                        <nav class="pagination-wrapper justify-content-center col-12" aria-label="Navigazione pagine documenti">
+                            <?php echo dci_bootstrap_pagination($the_query, false); ?>
+                        </nav>
+                    </div>
+                <?php endif; ?>
               </div>
             </div>
           </div>
@@ -91,5 +109,6 @@ get_header();
     <?php echo get_template_part( 'template-parts/common/assistenza-contatti'); ?>
 </main>
 <?php
+wp_reset_postdata();
 get_footer();
 ?>

--- a/template-parts/amministrazione-trasparente/articolazione-uffici/tutti-uffici.php
+++ b/template-parts/amministrazione-trasparente/articolazione-uffici/tutti-uffici.php
@@ -3,7 +3,7 @@ global $the_query, $load_posts;
 global $siti_tematici, $dci_amm_sidebar_embedded, $dci_amm_sidebar_sections;
 
 $count = 0;
-$max_posts = isset($_GET['max_posts']) ? (int) $_GET['max_posts'] : 1000000;
+$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 300, 300, 300);
 $load_posts = 6;
 $query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
 $siti_tematici = !empty(dci_get_option('siti_tematici', 'trasparenza')) ? dci_get_option('siti_tematici', 'trasparenza') : [];

--- a/template-parts/amministrazione-trasparente/atto-concessione/tutti-gli-atti.php
+++ b/template-parts/amministrazione-trasparente/atto-concessione/tutti-gli-atti.php
@@ -5,7 +5,7 @@ remove_filter('template_redirect', 'redirect_canonical');
 global $wpdb;
 
 // Lettura parametri da URL
-$max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 10;
+$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 10, 10, 50);
 $main_search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
 $paged_from_query = max(1, (int) get_query_var('paged'));
 $paged_from_page  = max(1, (int) get_query_var('page'));

--- a/template-parts/amministrazione-trasparente/incarichi-autorizzazioni/tutti-gli-incarichi.php
+++ b/template-parts/amministrazione-trasparente/incarichi-autorizzazioni/tutti-gli-incarichi.php
@@ -4,7 +4,7 @@ remove_filter('template_redirect', 'redirect_canonical');
 
 global $wpdb;
 
-$max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 5;
+$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 5, 5, 50);
 $main_search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
 $paged = max(1, (int) get_query_var('paged'));
 if ($paged < 2) {

--- a/template-parts/amministrazione-trasparente/titolare_incarico/tutti-titolari.php
+++ b/template-parts/amministrazione-trasparente/titolare_incarico/tutti-titolari.php
@@ -1,7 +1,7 @@
 <?php
 global $wpdb;
 
-$max_posts = isset($_GET['max_posts']) ? intval($_GET['max_posts']) : 10;
+$max_posts = dci_sanitize_posts_per_page(isset($_GET['max_posts']) ? $_GET['max_posts'] : 10, 10, 50);
 $main_search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
 $paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
 $selected_year = isset($_GET['filter_year']) ? intval($_GET['filter_year']) : 0;
@@ -37,7 +37,6 @@ if ($selected_year > 0) {
     ];
 }
 
-$the_query = new WP_Query($args);
 $prefix = "_dci_titolare_incarico_";
 
 // Query personalizzata

--- a/template-parts/amministrazione-trasparente/titolari-incarichi-poilitici/tutti-titolari.php
+++ b/template-parts/amministrazione-trasparente/titolari-incarichi-poilitici/tutti-titolari.php
@@ -19,7 +19,9 @@ if($portale_esterno === 'false'){
 
     $args = array(
         'post_type' => 'unita_organizzativa',
-        'posts_per_page' => -1,
+        'posts_per_page' => 100,
+        'no_found_rows' => true,
+        'update_post_meta_cache' => false,
         'tax_query' => array(
             array(
                 'taxonomy' => 'tipi_unita_organizzativa',

--- a/template-parts/politici/tutti-politici.php
+++ b/template-parts/politici/tutti-politici.php
@@ -22,14 +22,18 @@ $tax_query = array(
 $args_incarichi = array(
     'post_type' => 'incarico',
     'tax_query' => $tax_query,
-    'posts_per_page' => -1
+    'posts_per_page' => -1,
+    'fields' => 'ids',
+    'no_found_rows' => true,
+    'update_post_meta_cache' => false,
+    'update_post_term_cache' => false,
 );
 
 $incarichi_posts = get_posts($args_incarichi);
 $persone_ids = array();
 
-foreach($incarichi_posts as $incarico) {
-    $persone = get_post_meta($incarico->ID, '_dci_incarico_persona');
+foreach($incarichi_posts as $incarico_id) {
+    $persone = get_post_meta($incarico_id, '_dci_incarico_persona');
     foreach($persone as $persona) {
         $persone_ids[] = $persona;
     }
@@ -47,6 +51,7 @@ $args = array(
     'orderby' => 'post_title',
     'order' => 'ASC',
     'post__in' => empty($persone_ids) ? [0] : $filter_ids,
+    'no_found_rows' => true,
 );
 
 $the_query = new WP_Query($args);


### PR DESCRIPTION
### Motivation
- Improve accessibility toolbar theming so it adapts to site header colors and centralize color variables. 
- Make async template part loading more resilient to slow backends by reducing per-request timeouts, bounding retry windows, and using persistent object cache when available. 
- Harden AJAX list loading and theme templates to sanitize input, reduce DB work and support proper pagination to avoid performance and correctness issues.

### Description
- Introduces CSS custom properties for the accessibility toolbar and replaces hardcoded colors with `--dci-a11y-*` variables in `assets/css/accessibility-toolbar.css`. 
- Adds color detection and syncing logic to `assets/js/accessibility-toolbar.js` (`isVisibleColor`, `rgbParts`, `shadeColor`, `shadowColor`, `readHeaderColor`, `syncHeaderColor`) to pick accent colors from header and set CSS variables. 
- Reworks `assets/js/async-template-parts.js` to lower `timeoutMs` default to `12000`, add a `retryTimeoutMs` total retry window, track retry start time, stop retrying after the window, and reduce default concurrent fetches to `2`. 
- Adds server-side configuration and caching helpers in `functions.php` including `dci_async_template_parts_frontend_settings`, `dci_async_template_parts_use_persistent_cache` and a cache group and switches async template caching to `wp_cache_get`/`wp_cache_set` when an external object cache is present. 
- Centralizes external fragment HTTP args via `dci_get_external_fragment_request_args` and applies more conservative timeouts and longer negative caches in `inc/funzionalita_trasversali.php` and related functions to avoid repeated blocking requests. 
- Hardens and modernizes AJAX `load_more()` in `inc/load_more.php` by sanitizing inputs, supporting `tax_query` and `filter_ids`, using `WP_Query` instead of `query_posts`, enforcing `posts_per_page` and `post_status`, and returning JSON via `wp_send_json`. 
- Improves multiple template parts to use `dci_sanitize_posts_per_page`, add `no_found_rows` and cache-related query flags where appropriate, switch loops to proper `WP_Query` iteration, escape output with `esc_attr`, and add pagination markup where needed (e.g. `taxonomy-tipi_documento.php`). 
- Updates asset enqueuing to use `filemtime()` for versioning of changed CSS/JS files and localizes the new async template settings to the frontend script. 

### Testing
- No automated test suite was added for these changes and no integration tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a211fa3aeec8332be2b1c61a085b306)